### PR TITLE
ELIA-116 Removed randomness from cp lat and long

### DIFF
--- a/src/data/locations.ts
+++ b/src/data/locations.ts
@@ -163,8 +163,10 @@ function createLocation(
         postal_code: `${postalCode}`,
         country: `${country}`, 
         coordinates: {
-            latitude: `${(latitude + (Math.random() / 50)).toFixed(3)}`,
-            longitude: `${(longitude + (Math.random() / 50)).toFixed(3)}`,
+            // latitude: `${(latitude + (Math.random() / 50)).toFixed(3)}`,
+            // longitude: `${(longitude + (Math.random() / 50)).toFixed(3)}`,
+            latitude: `${latitude}`,
+            longitude: `${longitude}`,
         },
         operator: {
             name: cpo.business_details.name


### PR DESCRIPTION
Chargepoint lat and long is now specified, shouldn't be random.
I had misunderstood the randomness for the chargepoint locations, thought it to space out the connectors.