### PR TITLE
Feat/ev registry integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -216,9 +216,9 @@
       }
     },
     "@ethersproject/basex": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.5.tgz",
-      "integrity": "sha512-Echs7nWq1K/HqDaxnT0nJ2Qe5uXH5v/L6AdKVlH+FQ0FrRAMl0XgWoWECsYo9lt16/Pk4wiMksLvVEW8djluEg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.6.tgz",
+      "integrity": "sha512-Y/8dowRxBF3bsKkqEp7XN4kcFFQ0o5xxP1YyopfqkXejaOEGiD7ToQdQ0pIZpAJ5GreW56oFOTDDSO6ZcUCNYg==",
       "requires": {
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/properties": "^5.0.3"
@@ -235,9 +235,9 @@
       }
     },
     "@ethersproject/bytes": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.6.tgz",
-      "integrity": "sha512-axEmVeVy5IS0Sg46fNk4mygMm96uGd/15b6zmMu53w0NpHmOC/GYfpqMBHYxavjFYN+LUL7vVwgpbIFYGO2QHA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.8.tgz",
+      "integrity": "sha512-O+sJNVGzzuy51g+EMK8BegomqNIg+C2RO6vOt0XP6ac4o4saiq69FnjlsrNslaiMFVO7qcEHBsWJ9hx1tj1lMw==",
       "requires": {
         "@ethersproject/logger": "^5.0.5"
       }
@@ -267,9 +267,9 @@
       }
     },
     "@ethersproject/hash": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.7.tgz",
-      "integrity": "sha512-vYuRJRTAGHcYqQFAxxCgDpJtJv4aGC5TQm5NDZat/55BeLGLmH90ftJG1ldv7MhzGRxBPJtpqSHzJDizB6VKoA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.8.tgz",
+      "integrity": "sha512-Qay01tcFyFreYjSMt82rOQGMfQDmLm1sj3iNNO1BhrVf840xgBZuJ7gBATERzAjTuTCHUHw9BuGwxErJUS95yg==",
       "requires": {
         "@ethersproject/abstract-signer": "^5.0.6",
         "@ethersproject/address": "^5.0.5",
@@ -282,9 +282,9 @@
       }
     },
     "@ethersproject/hdnode": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.6.tgz",
-      "integrity": "sha512-cS2xZJZP7Tsaz695U0G3gdTYZatmSjHWY/VQGVc/E1DnLSBz0ZfQaikhU5uzDNLYaOfcEKd7helezrsfU2xguw==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.7.tgz",
+      "integrity": "sha512-89tphqlji4y/LNE1cSaMQ3hrBtJ4lO1qWGi2hn54LiHym85DTw+zAKbA8QgmdSdJDLGR/kc9VHaIPQ+vZQ2LkQ==",
       "requires": {
         "@ethersproject/abstract-signer": "^5.0.4",
         "@ethersproject/basex": "^5.0.3",
@@ -301,9 +301,9 @@
       }
     },
     "@ethersproject/json-wallets": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.8.tgz",
-      "integrity": "sha512-henOyQpUTfjI7JLCnEgMR+FYrj2VcGgLNjDSUmhOlGWagrvB9LPH/7MJaXr+GxBuPIRe8pkrD0hjIDD+PMMAZA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.9.tgz",
+      "integrity": "sha512-EWuFvJd8nu90dkmJwmJddxOYCvFvMkKBsZi8rxTme2XEZsHKOFnybVkoL23u7ZtApuEfTKmVcR2PTwgZwqDsKw==",
       "requires": {
         "@ethersproject/abstract-signer": "^5.0.4",
         "@ethersproject/address": "^5.0.4",
@@ -343,9 +343,9 @@
       }
     },
     "@ethersproject/pbkdf2": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.5.tgz",
-      "integrity": "sha512-cIi1idxnAE0mN0BqVAZ3/QDfAtl6fY2uvHgzjKmUwKt0+DR5Vsmo9vomSXxMm3zcoh4MyaPSc5XvU5GkPpOXKg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.6.tgz",
+      "integrity": "sha512-CUYciSxR/AaCoKMJk3WUW+BDhR41G3C+O9lOeZ4bR1wDhLKL2Z8p0ciF5XDEiVbmI4CToW6boVKybeVMdngRrg==",
       "requires": {
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/sha2": "^5.0.3"
@@ -360,9 +360,9 @@
       }
     },
     "@ethersproject/providers": {
-      "version": "5.0.16",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.16.tgz",
-      "integrity": "sha512-OCo0NH7VC8hfr7ESuZDMQl2Jdz2jpWulNGsWgnxXZT0tuPrrKHO+5BADS5s1W+YsovL3mKFkQjwGcOP2arvhzw==",
+      "version": "5.0.17",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.17.tgz",
+      "integrity": "sha512-bJnvs5X7ttU5x2ekGJYG7R3Z+spZawLFfR0IDsbaMDLiCwZOyrgk+VTBU7amSFLT0WUhWFv8WwSUB+AryCQG1Q==",
       "requires": {
         "@ethersproject/abstract-provider": "^5.0.4",
         "@ethersproject/abstract-signer": "^5.0.4",
@@ -393,9 +393,9 @@
       }
     },
     "@ethersproject/random": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.5.tgz",
-      "integrity": "sha512-MZU+W03FVEKeiKb9w/guTMiBa17Wub6mTNeVLQk8Nte/7onXt8iRgdPGoXquXhyM6lqL8PsxeunFYYa6azr0rA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.6.tgz",
+      "integrity": "sha512-8nsVNaZvZ9OD5NXfzE4mmz8IH/1DYJbAR95xpRxZkIuNmfn6QlMp49ccJYZWGhs6m0Zj2+FXjx3pzXfYlo9/dA==",
       "requires": {
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/logger": "^5.0.5"
@@ -469,9 +469,9 @@
       }
     },
     "@ethersproject/wallet": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.8.tgz",
-      "integrity": "sha512-sraAhJPuuvcfqh/Af1nkQzyozUb9yyQGtNEwcDgU4bzIoltnFpr3CzPoXN6QIxh/bKCYq2LG5++Jui2hjIIPuw==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.9.tgz",
+      "integrity": "sha512-GfpQF56PO/945SJq7Wdg5F5U6wkxaDgkAzcgGbCW6Joz8oW8MzKItkvYCzMh+j/8gJMzFncsuqX4zg2gq3J6nQ==",
       "requires": {
         "@ethersproject/abstract-provider": "^5.0.4",
         "@ethersproject/abstract-signer": "^5.0.4",
@@ -503,9 +503,9 @@
       }
     },
     "@ethersproject/wordlists": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.6.tgz",
-      "integrity": "sha512-dEs2DW+YcX/2y5zpAf9KF72zOtzlPbjG80LQlwX/YXoFH8eJpvaQyXJUHceeJhJBw8B6bgF6Ps9jW7VuGPrf6Q==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.7.tgz",
+      "integrity": "sha512-ZjQtYxm41FmHfYgpkdQG++EDcBPQWv9O6FfP6NndYRVaXaQZh6eq3sy7HQP8zCZ8dznKgy6ZyKECS8qdvnGHwA==",
       "requires": {
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/hash": "^5.0.4",
@@ -598,6 +598,38 @@
           "requires": {
             "ethers": "4.0.45",
             "web3": "1.2.6"
+          },
+          "dependencies": {
+            "elliptic": {
+              "version": "6.5.2",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
+              "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
+              }
+            },
+            "ethers": {
+              "version": "4.0.45",
+              "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.45.tgz",
+              "integrity": "sha512-N/Wmc6Mw4pQO+Sss1HnKDCSS6KSCx0luoBMiPNq+1GbOaO3YaZOyplBEhj+NEoYsizZYODtkITg2oecPeNnidQ==",
+              "requires": {
+                "aes-js": "3.0.0",
+                "bn.js": "^4.4.0",
+                "elliptic": "6.5.2",
+                "hash.js": "1.1.3",
+                "js-sha3": "0.5.7",
+                "scrypt-js": "2.0.4",
+                "setimmediate": "1.0.4",
+                "uuid": "2.0.1",
+                "xmlhttprequest": "1.8.0"
+              }
+            }
           }
         },
         "bl": {
@@ -610,6 +642,15 @@
             "readable-stream": "^3.4.0"
           }
         },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
         "readable-stream": {
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -619,6 +660,16 @@
             "string_decoder": "^1.1.1",
             "util-deprecate": "^1.0.1"
           }
+        },
+        "scrypt-js": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
         }
       }
     },
@@ -753,6 +804,57 @@
       "requires": {
         "ethers": "4.0.45",
         "web3": "1.2.6"
+      },
+      "dependencies": {
+        "elliptic": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
+          "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
+        },
+        "ethers": {
+          "version": "4.0.45",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.45.tgz",
+          "integrity": "sha512-N/Wmc6Mw4pQO+Sss1HnKDCSS6KSCx0luoBMiPNq+1GbOaO3YaZOyplBEhj+NEoYsizZYODtkITg2oecPeNnidQ==",
+          "requires": {
+            "aes-js": "3.0.0",
+            "bn.js": "^4.4.0",
+            "elliptic": "6.5.2",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.4",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          }
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "scrypt-js": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+        }
       }
     },
     "@metamask/detect-provider": {
@@ -820,6 +922,43 @@
       "requires": {
         "ethers": "^4.0.37",
         "jsonpath": "^1.0.2"
+      },
+      "dependencies": {
+        "ethers": {
+          "version": "4.0.48",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.48.tgz",
+          "integrity": "sha512-sZD5K8H28dOrcidzx9f8KYh8083n5BexIO3+SbE4jK83L85FxtpXZBCQdXb8gkg+7sBqomcLhhkU7UHL+F7I2g==",
+          "requires": {
+            "aes-js": "3.0.0",
+            "bn.js": "^4.4.0",
+            "elliptic": "6.5.3",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.4",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          }
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "scrypt-js": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+        }
       }
     },
     "@shareandcharge/ocn-registry": {
@@ -3054,13 +3193,13 @@
       }
     },
     "ethers": {
-      "version": "4.0.45",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.45.tgz",
-      "integrity": "sha512-N/Wmc6Mw4pQO+Sss1HnKDCSS6KSCx0luoBMiPNq+1GbOaO3YaZOyplBEhj+NEoYsizZYODtkITg2oecPeNnidQ==",
+      "version": "4.0.48",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.48.tgz",
+      "integrity": "sha512-sZD5K8H28dOrcidzx9f8KYh8083n5BexIO3+SbE4jK83L85FxtpXZBCQdXb8gkg+7sBqomcLhhkU7UHL+F7I2g==",
       "requires": {
         "aes-js": "3.0.0",
         "bn.js": "^4.4.0",
-        "elliptic": "6.5.2",
+        "elliptic": "6.5.3",
         "hash.js": "1.1.3",
         "js-sha3": "0.5.7",
         "scrypt-js": "2.0.4",
@@ -3069,20 +3208,6 @@
         "xmlhttprequest": "1.8.0"
       },
       "dependencies": {
-        "elliptic": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-          "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
-          "requires": {
-            "bn.js": "^4.4.0",
-            "brorand": "^1.0.1",
-            "hash.js": "^1.0.0",
-            "hmac-drbg": "^1.0.0",
-            "inherits": "^2.0.1",
-            "minimalistic-assert": "^1.0.0",
-            "minimalistic-crypto-utils": "^1.0.0"
-          }
-        },
         "hash.js": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
@@ -3727,10 +3852,66 @@
             "web3": "1.2.6"
           }
         },
+        "ethers": {
+          "version": "4.0.45",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.45.tgz",
+          "integrity": "sha512-N/Wmc6Mw4pQO+Sss1HnKDCSS6KSCx0luoBMiPNq+1GbOaO3YaZOyplBEhj+NEoYsizZYODtkITg2oecPeNnidQ==",
+          "requires": {
+            "aes-js": "3.0.0",
+            "bn.js": "^4.4.0",
+            "elliptic": "6.5.2",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.4",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          },
+          "dependencies": {
+            "elliptic": {
+              "version": "6.5.2",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
+              "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
+              }
+            },
+            "js-sha3": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+              "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+            },
+            "uuid": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+              "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+            }
+          }
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
         "js-sha3": {
           "version": "0.8.0",
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
           "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+        },
+        "scrypt-js": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
         },
         "uuid": {
           "version": "7.0.3",
@@ -7274,6 +7455,36 @@
           "version": "12.19.6",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.6.tgz",
           "integrity": "sha512-U2VopDdmBoYBmtm8Rz340mvvSz34VgX/K9+XCuckvcLGMkt3rbMX8soqFOikIPlPBc5lmw8By9NUK7bEFSBFlQ=="
+        },
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+        },
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.6.tgz",
+          "integrity": "sha512-8/HnqG/l7dGmKMgEL9JeKPTtjScxOePTzopv5aaKFExPfaBrYRkgoMqhoowCiAl/s16QaTn4DoIF1QC4YsT7Mg==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
         }
       }
     },
@@ -7312,6 +7523,36 @@
           "version": "12.19.6",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.6.tgz",
           "integrity": "sha512-U2VopDdmBoYBmtm8Rz340mvvSz34VgX/K9+XCuckvcLGMkt3rbMX8soqFOikIPlPBc5lmw8By9NUK7bEFSBFlQ=="
+        },
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+        },
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.6.tgz",
+          "integrity": "sha512-8/HnqG/l7dGmKMgEL9JeKPTtjScxOePTzopv5aaKFExPfaBrYRkgoMqhoowCiAl/s16QaTn4DoIF1QC4YsT7Mg==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
         }
       }
     },
@@ -7323,6 +7564,38 @@
         "underscore": "1.9.1",
         "web3-eth-iban": "1.2.6",
         "web3-utils": "1.2.6"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+        },
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.6.tgz",
+          "integrity": "sha512-8/HnqG/l7dGmKMgEL9JeKPTtjScxOePTzopv5aaKFExPfaBrYRkgoMqhoowCiAl/s16QaTn4DoIF1QC4YsT7Mg==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-core-method": {
@@ -7335,6 +7608,38 @@
         "web3-core-promievent": "1.2.6",
         "web3-core-subscriptions": "1.2.6",
         "web3-utils": "1.2.6"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+        },
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.6.tgz",
+          "integrity": "sha512-8/HnqG/l7dGmKMgEL9JeKPTtjScxOePTzopv5aaKFExPfaBrYRkgoMqhoowCiAl/s16QaTn4DoIF1QC4YsT7Mg==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-core-promievent": {
@@ -7386,6 +7691,38 @@
         "web3-eth-personal": "1.2.6",
         "web3-net": "1.2.6",
         "web3-utils": "1.2.6"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+        },
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.6.tgz",
+          "integrity": "sha512-8/HnqG/l7dGmKMgEL9JeKPTtjScxOePTzopv5aaKFExPfaBrYRkgoMqhoowCiAl/s16QaTn4DoIF1QC4YsT7Mg==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-eth-abi": {
@@ -7412,6 +7749,32 @@
             "brorand": "^1.0.1",
             "hash.js": "^1.0.0",
             "inherits": "^2.0.1"
+          }
+        },
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          },
+          "dependencies": {
+            "elliptic": {
+              "version": "6.5.3",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+              "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
+              }
+            }
           }
         },
         "ethers": {
@@ -7449,6 +7812,28 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
           "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+        },
+        "web3-utils": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.6.tgz",
+          "integrity": "sha512-8/HnqG/l7dGmKMgEL9JeKPTtjScxOePTzopv5aaKFExPfaBrYRkgoMqhoowCiAl/s16QaTn4DoIF1QC4YsT7Mg==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+            }
+          }
         }
       }
     },
@@ -7485,6 +7870,38 @@
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
           "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        },
+        "web3-utils": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.6.tgz",
+          "integrity": "sha512-8/HnqG/l7dGmKMgEL9JeKPTtjScxOePTzopv5aaKFExPfaBrYRkgoMqhoowCiAl/s16QaTn4DoIF1QC4YsT7Mg==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+            },
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            }
+          }
         }
       }
     },
@@ -7502,6 +7919,38 @@
         "web3-core-subscriptions": "1.2.6",
         "web3-eth-abi": "1.2.6",
         "web3-utils": "1.2.6"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+        },
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.6.tgz",
+          "integrity": "sha512-8/HnqG/l7dGmKMgEL9JeKPTtjScxOePTzopv5aaKFExPfaBrYRkgoMqhoowCiAl/s16QaTn4DoIF1QC4YsT7Mg==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-eth-ens": {
@@ -7517,6 +7966,38 @@
         "web3-eth-abi": "1.2.6",
         "web3-eth-contract": "1.2.6",
         "web3-utils": "1.2.6"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+        },
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.6.tgz",
+          "integrity": "sha512-8/HnqG/l7dGmKMgEL9JeKPTtjScxOePTzopv5aaKFExPfaBrYRkgoMqhoowCiAl/s16QaTn4DoIF1QC4YsT7Mg==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-eth-iban": {
@@ -7532,6 +8013,31 @@
           "version": "4.11.8",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
           "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+        },
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.6.tgz",
+          "integrity": "sha512-8/HnqG/l7dGmKMgEL9JeKPTtjScxOePTzopv5aaKFExPfaBrYRkgoMqhoowCiAl/s16QaTn4DoIF1QC4YsT7Mg==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
         }
       }
     },
@@ -7552,6 +8058,36 @@
           "version": "12.19.6",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.6.tgz",
           "integrity": "sha512-U2VopDdmBoYBmtm8Rz340mvvSz34VgX/K9+XCuckvcLGMkt3rbMX8soqFOikIPlPBc5lmw8By9NUK7bEFSBFlQ=="
+        },
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+        },
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.6.tgz",
+          "integrity": "sha512-8/HnqG/l7dGmKMgEL9JeKPTtjScxOePTzopv5aaKFExPfaBrYRkgoMqhoowCiAl/s16QaTn4DoIF1QC4YsT7Mg==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
         }
       }
     },
@@ -7563,6 +8099,38 @@
         "web3-core": "1.2.6",
         "web3-core-method": "1.2.6",
         "web3-utils": "1.2.6"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+        },
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.6.tgz",
+          "integrity": "sha512-8/HnqG/l7dGmKMgEL9JeKPTtjScxOePTzopv5aaKFExPfaBrYRkgoMqhoowCiAl/s16QaTn4DoIF1QC4YsT7Mg==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-provider-engine": {
@@ -7673,12 +8241,12 @@
       }
     },
     "web3-utils": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.6.tgz",
-      "integrity": "sha512-8/HnqG/l7dGmKMgEL9JeKPTtjScxOePTzopv5aaKFExPfaBrYRkgoMqhoowCiAl/s16QaTn4DoIF1QC4YsT7Mg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.0.tgz",
+      "integrity": "sha512-2mS5axFCbkhicmoDRuJeuo0TVGQDgC2sPi/5dblfVC+PMtX0efrb8Xlttv/eGkq7X4E83Pds34FH98TP2WOUZA==",
       "requires": {
-        "bn.js": "4.11.8",
-        "eth-lib": "0.2.7",
+        "bn.js": "^4.11.9",
+        "eth-lib": "0.2.8",
         "ethereum-bloom-filters": "^1.0.6",
         "ethjs-unit": "0.1.6",
         "number-to-bn": "1.7.0",
@@ -7687,15 +8255,10 @@
         "utf8": "3.0.0"
       },
       "dependencies": {
-        "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
-        },
         "eth-lib": {
-          "version": "0.2.7",
-          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
           "requires": {
             "bn.js": "^4.11.6",
             "elliptic": "^6.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -153,6 +153,22 @@
       "resolved": "https://registry.npmjs.org/@ensdomains/resolver/-/resolver-0.2.4.tgz",
       "integrity": "sha512-bvaTH34PMCbv6anRa9I/0zjLJgY4EuznbEMgbV77JBCQ9KNC46rzi0avuxpOfu+xDjPEtSFGqVEOr5GlUSGudA=="
     },
+    "@ethersproject/abi": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.9.tgz",
+      "integrity": "sha512-ily2OufA2DTrxkiHQw5GqbkMSnNKuwZBqKsajtT0ERhZy1r9w2CpW1bmtRMIGzaqQxCdn/GEoFogexk72cBBZQ==",
+      "requires": {
+        "@ethersproject/address": "^5.0.4",
+        "@ethersproject/bignumber": "^5.0.7",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/constants": "^5.0.4",
+        "@ethersproject/hash": "^5.0.4",
+        "@ethersproject/keccak256": "^5.0.3",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/properties": "^5.0.3",
+        "@ethersproject/strings": "^5.0.4"
+      }
+    },
     "@ethersproject/abstract-provider": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.6.tgz",
@@ -234,6 +250,22 @@
         "@ethersproject/bignumber": "^5.0.7"
       }
     },
+    "@ethersproject/contracts": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.8.tgz",
+      "integrity": "sha512-PecBL4vnsrpuks2lzzkRsOts8csJy338HNDKDIivbFmx92BVzh3ohOOv3XsoYPSXIHQvobF959W+aSk3RCZL/g==",
+      "requires": {
+        "@ethersproject/abi": "^5.0.5",
+        "@ethersproject/abstract-provider": "^5.0.4",
+        "@ethersproject/abstract-signer": "^5.0.4",
+        "@ethersproject/address": "^5.0.4",
+        "@ethersproject/bignumber": "^5.0.7",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/constants": "^5.0.4",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/properties": "^5.0.3"
+      }
+    },
     "@ethersproject/hash": {
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.7.tgz",
@@ -289,9 +321,9 @@
       }
     },
     "@ethersproject/keccak256": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.5.tgz",
-      "integrity": "sha512-9hXXp113jW5yPf27krofmnZ26u5SXsmuvrMTUuXyVdIDIJDLGorVyB2bBiWwENVok92E4WDnfAZHG+A+E6TCMQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.6.tgz",
+      "integrity": "sha512-eJ4Id/i2rwrf5JXEA7a12bG1phuxjj47mPZgDUbttuNBodhSuZF2nEO5QdpaRjmlphQ8Kt9PNqY/z7lhtJptZg==",
       "requires": {
         "@ethersproject/bytes": "^5.0.4",
         "js-sha3": "0.5.7"

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "license": "Apache-2.0",
   "homepage": "https://bitbucket.org/shareandcharge/ocn-tools#readme",
   "dependencies": {
+    "@ethersproject/bytes": "^5.0.8",
     "@ethersproject/contracts": "^5.0.8",
-    "@ethersproject/keccak256": "^5.0.6",
     "@ethersproject/providers": "^5.0.16",
     "@ethersproject/wallet": "^5.0.8",
     "@ew-did-registry/did": "0.0.1-alpha.694.1",
@@ -31,11 +31,13 @@
     "@ew-did-registry/keys": "0.0.1-alpha.694.1",
     "@shareandcharge/ocn-bridge": "git+https://github.com/energywebfoundation/ocn-bridge.git#v2",
     "better-sqlite3": "^5.4.3",
+    "ethers": "^4.0.48",
     "iam-client-lib": "file:iam-client-lib-1.0.3.tgz",
     "nats": "^1.4.12",
     "random-js": "^2.1.0",
     "tslib": "^2.0.3",
     "uuid": "^3.3.3",
+    "web3-utils": "^1.3.0",
     "yargs": "^14.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   "license": "Apache-2.0",
   "homepage": "https://bitbucket.org/shareandcharge/ocn-tools#readme",
   "dependencies": {
+    "@ethersproject/contracts": "^5.0.8",
+    "@ethersproject/keccak256": "^5.0.6",
     "@ethersproject/providers": "^5.0.16",
     "@ethersproject/wallet": "^5.0.8",
     "@ew-did-registry/did": "0.0.1-alpha.694.1",

--- a/src/config/config.docker.ts
+++ b/src/config/config.docker.ts
@@ -65,5 +65,9 @@ export const config: IOcnToolsConfig = {
         natsServerUrl: process.env.NATS_SERVER_URL ?? "13.52.78.249",
         natsProtocolPort: process.env.NATS_PROTOCOL_PORT ?? "4222",
         webSocketsProtocolPort: process.env.WS_PROTOCOL_PORT ?? "9222"
+    },
+    evRegistry: {
+        address: process.env.EV_REGISTRY_ADDRESS || "0x9fbda871d559710256a2502a2517b794b482db40",
+        provider: process.env.EV_REGISTRY_PROVIDER || "http://172.16.238.10:8544"
     }
 }

--- a/src/config/config.local.ts
+++ b/src/config/config.local.ts
@@ -61,5 +61,9 @@ export const config: IOcnToolsConfig = {
         natsServerUrl: process.env.NATS_SERVER_URL ?? "13.52.78.249",
         natsProtocolPort: process.env.NATS_PROTOCOL_PORT ?? "4222",
         webSocketsProtocolPort: process.env.WS_PROTOCOL_PORT ?? "9222"
+    },
+    evRegistry: {
+        address: "0x9fbda871d559710256a2502a2517b794b482db40",
+        provider: "http://localhost:8544"
     }
 }

--- a/src/config/config.volta.ts
+++ b/src/config/config.volta.ts
@@ -19,7 +19,7 @@ import { IOcnToolsConfig } from "../types"
 export const config: IOcnToolsConfig = {
     ocn: {
         node: "http://node.ocn.org",
-        stage: "local"
+        stage: "volta"
     },
     cpo: {
         port: 3000,
@@ -61,5 +61,9 @@ export const config: IOcnToolsConfig = {
         natsServerUrl: process.env.NATS_SERVER_URL ?? "13.52.78.249",
         natsProtocolPort: process.env.NATS_PROTOCOL_PORT ?? "4222",
         webSocketsProtocolPort: process.env.WS_PROTOCOL_PORT ?? "9222"
+    },
+    evRegistry: {
+        address: "0x8d80504617eB17816b91610Fb2a0274Dc70f193f",
+        provider: "https://volta-internal-archive.energyweb.org"
     }
 }

--- a/src/data/tokens.ts
+++ b/src/data/tokens.ts
@@ -28,7 +28,7 @@ export const tokens: IToken[] = []
 for (let i = 1; i <= config.msp.assetCount; i++) {
     const max = 99999999
     const randomInt = integer(0, max)(mt)
-    const uid = ("0000000" + randomInt).slice(-8) // Ensure that uid is 8 digits
+    const uid = ("111111" + randomInt).slice(-8) // Ensure that uid is 8 digits
 
     // Sample VIN prefixes for Mercedes-Benz
     // https://www.lastvin.com/de/

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,11 +48,6 @@ const createAssetDIDs = async (operatorType: "msp" | "cpo", db: IDIDCache) => {
     // add user to ev registry (needs to be done before devices are added)
     const evRegistry = new EvRegistry(key)
     await evRegistry.addUser()
-
-    setTimeout(async () => {
-        console.log("Testing retry add user to EV Registry")
-        await evRegistry.addUser()
-    }, 20 * 1000)
     
     const factory = new DIDFactory(key, db)
     if (operatorType === "msp") {

--- a/src/models/contracts/ev-registry.abi.ts
+++ b/src/models/contracts/ev-registry.abi.ts
@@ -1,0 +1,166 @@
+export default [
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "ocnRegistry",
+                "type": "address"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "constant": true,
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "devices",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "user",
+                "type": "address"
+            },
+            {
+                "internalType": "string",
+                "name": "identifier",
+                "type": "string"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "constant": false,
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "user",
+                "type": "address"
+            },
+            {
+                "internalType": "uint8",
+                "name": "v",
+                "type": "uint8"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "r",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "s",
+                "type": "bytes32"
+            }
+        ],
+        "name": "addUser",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "constant": false,
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "device",
+                "type": "address"
+            },
+            {
+                "internalType": "string",
+                "name": "identifier",
+                "type": "string"
+            },
+            {
+                "internalType": "address",
+                "name": "user",
+                "type": "address"
+            },
+            {
+                "internalType": "uint8",
+                "name": "v",
+                "type": "uint8"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "r",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "s",
+                "type": "bytes32"
+            }
+        ],
+        "name": "addDevice",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "constant": true,
+        "inputs": [],
+        "name": "getAllUserAddresses",
+        "outputs": [
+            {
+                "internalType": "address[]",
+                "name": "",
+                "type": "address[]"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "constant": true,
+        "inputs": [],
+        "name": "getAllDeviceAddresses",
+        "outputs": [
+            {
+                "internalType": "address[]",
+                "name": "",
+                "type": "address[]"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "constant": true,
+        "inputs": [
+            {
+                "internalType": "string",
+                "name": "identifier",
+                "type": "string"
+            }
+        ],
+        "name": "getDeviceFromIdentifier",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "addr",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "user",
+                "type": "address"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+    }
+]

--- a/src/models/contracts/ev-registry.ts
+++ b/src/models/contracts/ev-registry.ts
@@ -1,46 +1,40 @@
+import { arrayify, Signature, splitSignature } from "@ethersproject/bytes"
 import { Contract } from "@ethersproject/contracts"
-import { keccak256 } from "@ethersproject/keccak256"
 import { JsonRpcProvider } from "@ethersproject/providers"
 import { Wallet } from "@ethersproject/wallet"
 import { Keys } from "@ew-did-registry/keys"
+import { soliditySha3 } from "web3-utils"
 import { config } from "../../config/config"
 import abi from "./ev-registry.abi"
 
 export class EvRegistry {
 
     private readonly contract: Contract
-    private readonly subject: Wallet
 
-    constructor(operatorKeys: Keys, subjectKeys?: Keys) {
+    constructor(operatorKeys: Keys) {
         if (!config.evRegistry) {
             throw Error("EV Registry contract address not set in config.")
         }
         const provider = new JsonRpcProvider(config.evRegistry?.provider)
         const signer = new Wallet(operatorKeys.privateKey, provider)
         this.contract = new Contract(config.evRegistry.address, abi, signer)
-        this.subject = new Wallet(
-            subjectKeys ? subjectKeys.privateKey : operatorKeys.privateKey
-        )
     }
 
     /**
      * Check for existence of user
      */
     public async userExists(): Promise<boolean> {
-        const user = this.subject.address
+        const user = await this.contract.signer.getAddress()
         const exists = await this.contract.getAllUserAddresses()
-        console.log(`[EV REGISTRY] Checking user ${user} against ${JSON.stringify(exists)}`)
         return exists.includes(user)
     }
 
     /**
      * Check for existence of device
      */
-    public async deviceExists(): Promise<boolean> {
-        const device = this.subject.address
+    public async deviceExists(address: string): Promise<boolean> {
         const exists = await this.contract.getAllDeviceAddresses()
-        console.log(`[EV REGISTRY] Checking device ${device} against ${JSON.stringify(exists)}`)
-        return exists.includes(device)
+        return exists.includes(address)
     }
 
     /**
@@ -48,42 +42,37 @@ export class EvRegistry {
      */
     public async addUser(): Promise<void> {
         if (await this.userExists()) {
-            console.log('SKIPPING ADDUSER...')
             return
         }
-        const user = this.subject.address
+        const user = await this.contract.signer.getAddress()
         const { r, s, v } = await this.getSignature(user)
-        console.log("r", r, "s", s, "v", v)
         await this.contract.addUser(user, v, r, s)
     }
 
     /**
      * Adds asset (vehicle/charge point, represented by wallet) to registry contract
      */
-    public async addDevice(uid: string, userAddress: string): Promise<void> {
-        if (await this.deviceExists()) {
-            console.log('SKIPPING ADDDEVICE')
+    public async addDevice(address: string, uid: string): Promise<void> {
+        if (await this.deviceExists(address)) {
             return
         }
-        const device = this.subject.address
-        const { r, v, s } = await this.getSignature(device, uid, userAddress)
-        console.log("r", r, "s", s, "v", v)
-        await this.contract.addDevice(device, uid, userAddress, v, r, s)
+        const user = await this.contract.signer.getAddress()
+        // convert uid to buffer so vehicle ID isn't parsed as an integer 
+        const { r, v, s } = await this.getSignature(address, Buffer.from(uid), user)
+        await this.contract.addDevice(address, uid, user, v, r, s)
     }
 
     /**
-     * EV Registry contract allows for transaction relaying. We can use the operator to
-     * pay for the transaction.
+     * EV Registry contract allows for transaction relaying but requires the
+     * operator to add devices (i.e. can't be signed by device)
+     * 
      * @param params arbitrary number of parameters that will be signed
      */
-    private async getSignature(...params: any[]): Promise<{ r: string, s: string, v: number }> {
-        const hash = keccak256(params.join(""))
-        const signature = await this.subject.signMessage(hash)
-        return {
-            r: `0x${signature.slice(2, 66)}`,
-            s: `0x${signature.slice(66, 130)}`,
-            v: Number(`0x${signature.slice(130)}`)
-        }
+    private async getSignature(...params: any[]): Promise<Signature> {
+        const hash = soliditySha3(...params)
+        const hashBytes = arrayify(hash as string)
+        const signature = await this.contract.signer.signMessage(hashBytes)
+        return splitSignature(signature)
     }
 
 } 

--- a/src/models/contracts/ev-registry.ts
+++ b/src/models/contracts/ev-registry.ts
@@ -1,0 +1,89 @@
+import { Contract } from "@ethersproject/contracts"
+import { keccak256 } from "@ethersproject/keccak256"
+import { JsonRpcProvider } from "@ethersproject/providers"
+import { Wallet } from "@ethersproject/wallet"
+import { Keys } from "@ew-did-registry/keys"
+import { config } from "../../config/config"
+import abi from "./ev-registry.abi"
+
+export class EvRegistry {
+
+    private readonly contract: Contract
+    private readonly subject: Wallet
+
+    constructor(operatorKeys: Keys, subjectKeys?: Keys) {
+        if (!config.evRegistry) {
+            throw Error("EV Registry contract address not set in config.")
+        }
+        const provider = new JsonRpcProvider(config.evRegistry?.provider)
+        const signer = new Wallet(operatorKeys.privateKey, provider)
+        this.contract = new Contract(config.evRegistry.address, abi, signer)
+        this.subject = new Wallet(
+            subjectKeys ? subjectKeys.privateKey : operatorKeys.privateKey
+        )
+    }
+
+    /**
+     * Check for existence of user
+     */
+    public async userExists(): Promise<boolean> {
+        const user = this.subject.address
+        const exists = await this.contract.getAllUserAddresses()
+        console.log(`[EV REGISTRY] Checking user ${user} against ${JSON.stringify(exists)}`)
+        return exists.includes(user)
+    }
+
+    /**
+     * Check for existence of device
+     */
+    public async deviceExists(): Promise<boolean> {
+        const device = this.subject.address
+        const exists = await this.contract.getAllDeviceAddresses()
+        console.log(`[EV REGISTRY] Checking device ${device} against ${JSON.stringify(exists)}`)
+        return exists.includes(device)
+    }
+
+    /**
+     * Adds user (MSP/CPO, represented by wallet) to registry contract 
+     */
+    public async addUser(): Promise<void> {
+        if (await this.userExists()) {
+            console.log('SKIPPING ADDUSER...')
+            return
+        }
+        const user = this.subject.address
+        const { r, s, v } = await this.getSignature(user)
+        console.log("r", r, "s", s, "v", v)
+        await this.contract.addUser(user, v, r, s)
+    }
+
+    /**
+     * Adds asset (vehicle/charge point, represented by wallet) to registry contract
+     */
+    public async addDevice(uid: string, userAddress: string): Promise<void> {
+        if (await this.deviceExists()) {
+            console.log('SKIPPING ADDDEVICE')
+            return
+        }
+        const device = this.subject.address
+        const { r, v, s } = await this.getSignature(device, uid, userAddress)
+        console.log("r", r, "s", s, "v", v)
+        await this.contract.addDevice(device, uid, userAddress, v, r, s)
+    }
+
+    /**
+     * EV Registry contract allows for transaction relaying. We can use the operator to
+     * pay for the transaction.
+     * @param params arbitrary number of parameters that will be signed
+     */
+    private async getSignature(...params: any[]): Promise<{ r: string, s: string, v: number }> {
+        const hash = keccak256(params.join(""))
+        const signature = await this.subject.signMessage(hash)
+        return {
+            r: `0x${signature.slice(2, 66)}`,
+            s: `0x${signature.slice(66, 130)}`,
+            v: Number(`0x${signature.slice(130)}`)
+        }
+    }
+
+} 

--- a/src/models/dids/did-factory.ts
+++ b/src/models/dids/did-factory.ts
@@ -13,7 +13,7 @@ export class DIDFactory {
      * @param operatorKey key used to 'control' the DID (asset operator)
      * @param db local DID cache for tracking which assets have DIDs
      */
-    constructor(private operatorKey: Keys, private db: IDIDCache) {}
+    constructor(private operatorKey: Keys, private db: IDIDCache, private skipRegistry?: boolean) {}
 
     /**
      * Create (or resolve) a vehicle's DID
@@ -21,7 +21,7 @@ export class DIDFactory {
      * @param token an MSP token representing a vehicle
      */
     public async createVehicleDID(token: IToken): Promise<DID> {
-        return DID.init(token.uid, this.operatorKey, this.db)
+        return DID.init(token.uid, this.operatorKey, this.db, this.skipRegistry)
     }
 
     /**
@@ -37,7 +37,7 @@ export class DIDFactory {
         const dids: DID[] = []
         for (const evse of evses) {
             if (evse.evse_id) {
-                const did = await DID.init(evse.evse_id, this.operatorKey, this.db)
+                const did = await DID.init(evse.evse_id, this.operatorKey, this.db, this.skipRegistry)
                 dids.push(did)
             }
         }

--- a/src/models/dids/did.ts
+++ b/src/models/dids/did.ts
@@ -17,8 +17,8 @@ export class DID {
      * @param operatorKey key of asset operator ('controller' of DID)
      * @param db interface with get/set identity cache methods
      */
-    public static async init(assetID: string, operatorKeys: Keys, db: IDIDCache): Promise<DID> {
-        const did = new DID(assetID, operatorKeys, db)
+    public static async init(assetID: string, operatorKeys: Keys, db: IDIDCache, skipRegistry?: boolean): Promise<DID> {
+        const did = new DID(assetID, operatorKeys, db, skipRegistry)
         await did.init()
         return did
     }
@@ -45,7 +45,8 @@ export class DID {
     constructor(
         private assetID: string,
         private operatorKeys: Keys,
-        private db: IDIDCache
+        private db: IDIDCache,
+        private skipRegistry?: boolean
     ) {}
 
     /**
@@ -88,7 +89,9 @@ export class DID {
         // log asset DID creation
         console.log(`[DID] Created identity for ${this.assetID}: ${this.did}`)
         // cache identity
-        await this.saveInEvRegistry(address, this.assetID)
+        if (!this.skipRegistry) {
+            await this.saveInEvRegistry(address, this.assetID)
+        }
         this.db.setAssetIdentity({
             uid: this.assetID,
             did: this.did,

--- a/src/services/iam-client-lib-service.ts
+++ b/src/services/iam-client-lib-service.ts
@@ -6,6 +6,9 @@ export class iamClientLibService {
 
     constructor(privateKey: string) {
         console.log(privateKey)
+        if (!config.iam) {
+            throw Error("No IAM configured. Unable to connect to IAM Cache Client.")
+        }
         const cacheClient = new CacheServerClient({
             url: config.iam.cacheServerUrl
         });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -27,13 +27,17 @@ export interface IOcnToolsConfig {
     },
     cpo: IMockServerConfig
     msp: IMockMSPServerConfig
-    iam: {
+    iam?: {
         cacheServerUrl: string
         rpcUrl: string
         chainId: number
         natsServerUrl: string
         natsProtocolPort: string
         webSocketsProtocolPort: string
+    },
+    evRegistry?: {
+        address: string
+        provider: string
     }
 }
 

--- a/test/dids/asset.spec.ts
+++ b/test/dids/asset.spec.ts
@@ -24,7 +24,7 @@ describe("DID Creation", () => {
 
     before(() => {
         db = new Database("test.db")
-        assetIdentityFactory = new DIDFactory(operatorKey, db)
+        assetIdentityFactory = new DIDFactory(operatorKey, db, true)
     })
 
     after(() => {


### PR DESCRIPTION
- EV Registry contract wrapper (we can re-use this in frontend/backend too)
- Stores user (MSP/CPO) in registry on start (if not already)
- Stores device (vehicle/charge point) in registry on DID creation (if not already)

Some findings:
- I previously designed the registry contract so that the user adds their devices. I guess this is still desirable, even though the device controls their own DID. If devices were to add themselves we'd need extra proof that they are "operated" by the user they claim. 
- The contract isn't too efficient when it comes to fetching data. The `users` map is made private, yet `devices` is public. So to check if a listing already exists, I had to call `fetchAll<type>Addresses` and see if it's in that array. I wanted to avoid a redeploy over this, so just something to keep in mind when we iterate on the features of the contract in the future.
-  Another issue with discrepancies between js and solidity keccak256. Had to convert the Vehicle UID to buffer before signing because web3-utils `soliditySha3` was parsing it as an integer and probably doing something else to it. Can think about switching from web3 to ethers for that at some point. 