### PR TITLE
remove hardcoded low gasprice to use default

### DIFF
--- a/src/data/tokens.ts
+++ b/src/data/tokens.ts
@@ -21,7 +21,7 @@ import { extractMSP } from "../tools/tools"
 
 const msp = extractMSP(config.msp.roles)
 
-const mt = MersenneTwister19937.seed(1)
+const mt = MersenneTwister19937.seed(2)
 
 export const tokens: IToken[] = []
 

--- a/src/models/dids/did.ts
+++ b/src/models/dids/did.ts
@@ -110,7 +110,6 @@ export class DID {
         const tx = await wallet.sendTransaction({
             to: assetAddress,
             value: valueInEther * 1e18, // convert to wei
-            gasPrice: 1
         })
         await tx.wait()
         // log remaining balance


### PR DESCRIPTION
Removes the hardcoded `gasPrice: 1` which can cause issues with the mint transaction in DID creation.

I also bumped the seed so we can start with a fresh state of tokens. But a better solution is needed in the future (i.e. a more robust contract). 