### PR TITLE
feat: update iam-client initialization to 2.0 API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,87 @@
         "@babel/highlight": "^7.10.4"
       }
     },
+    "@babel/compat-data": {
+      "version": "7.13.11",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.11.tgz",
+      "integrity": "sha512-BwKEkO+2a67DcFeS3RLl0Z3Gs2OvdXewuWjc1Hfokhb5eQWP9YRYH1/+VrVZvql2CfjOiNGqSAFOYt4lsqTHzg=="
+    },
+    "@babel/generator": {
+      "version": "7.13.9",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
+      "integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
+      "requires": {
+        "@babel/types": "^7.13.0",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        }
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.10.tgz",
+      "integrity": "sha512-/Xju7Qg1GQO4mHZ/Kcs6Au7gfafgZnwm+a7sy/ow/tV1sHeraRUHbjdat8/UvDor4Tez+siGKDk6zIKtCPKVJA==",
+      "requires": {
+        "@babel/compat-data": "^7.13.8",
+        "@babel/helper-validator-option": "^7.12.17",
+        "browserslist": "^4.14.5",
+        "semver": "^6.3.0"
+      }
+    },
+    "@babel/helper-define-polyfill-provider": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.1.5.tgz",
+      "integrity": "sha512-nXuzCSwlJ/WKr8qxzW816gwyT6VZgiJG17zR40fou70yfAcqjoNyTLl/DQ+FExw5Hx5KNqshmN8Ldl/r2N7cTg==",
+      "requires": {
+        "@babel/helper-compilation-targets": "^7.13.0",
+        "@babel/helper-module-imports": "^7.12.13",
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/traverse": "^7.13.0",
+        "debug": "^4.1.1",
+        "lodash.debounce": "^4.0.8",
+        "resolve": "^1.14.2",
+        "semver": "^6.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+      "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.12.13",
+        "@babel/template": "^7.12.13",
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+      "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+      "requires": {
+        "@babel/types": "^7.12.13"
+      }
+    },
     "@babel/helper-module-imports": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz",
@@ -22,15 +103,28 @@
       }
     },
     "@babel/helper-plugin-utils": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+      "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ=="
+    },
+    "@babel/helper-split-export-declaration": {
       "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.12.13.tgz",
-      "integrity": "sha512-C+10MXCXJLiR6IeG9+Wiejt9jmtFpxUc3MQqCmPY8hfCjyUGl9kT+B2okzEZrtykiwrc4dbCPdDoz0A/HQbDaA=="
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+      "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+      "requires": {
+        "@babel/types": "^7.12.13"
+      }
     },
     "@babel/helper-validator-identifier": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
       "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
       "dev": true
+    },
+    "@babel/helper-validator-option": {
+      "version": "7.12.17",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
+      "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw=="
     },
     "@babel/highlight": {
       "version": "7.10.4",
@@ -101,35 +195,223 @@
         }
       }
     },
+    "@babel/parser": {
+      "version": "7.13.11",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.11.tgz",
+      "integrity": "sha512-PhuoqeHoO9fc4ffMEVk4qb/w/s2iOSWohvbHxLtxui0eBg3Lg5gN1U8wp1V1u61hOWkPQJJyJzGH6Y+grwkq8Q=="
+    },
     "@babel/plugin-transform-runtime": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.12.13.tgz",
-      "integrity": "sha512-ho1CV2lm8qn2AxD3JdvPgtLVHCYLDaOszlf0gosdHcJAIfgNizag76WI+FoibrvfT+h117fgf8h+wgvo4O2qbA==",
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.13.10.tgz",
+      "integrity": "sha512-Y5k8ipgfvz5d/76tx7JYbKQTcgFSU6VgJ3kKQv4zGTKr+a9T/KBvfRvGtSFgKDQGt/DBykQixV0vNWKIdzWErA==",
       "requires": {
         "@babel/helper-module-imports": "^7.12.13",
-        "@babel/helper-plugin-utils": "^7.12.13",
-        "semver": "^5.5.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "babel-plugin-polyfill-corejs2": "^0.1.4",
+        "babel-plugin-polyfill-corejs3": "^0.1.3",
+        "babel-plugin-polyfill-regenerator": "^0.1.2",
+        "semver": "^6.3.0"
       }
     },
     "@babel/runtime": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.13.tgz",
-      "integrity": "sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==",
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+      "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
     },
-    "@babel/types": {
+    "@babel/template": {
       "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.13.tgz",
-      "integrity": "sha512-oKrdZTld2im1z8bDwTOQvUbxKwE+854zc16qWZQlcTqMN00pWxHQ4ZeOq0yDMnisOpRykH2/5Qqcrk/OlbAjiQ==",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+      "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+      "requires": {
+        "@babel/code-frame": "^7.12.13",
+        "@babel/parser": "^7.12.13",
+        "@babel/types": "^7.12.13"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+          "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+          "requires": {
+            "@babel/highlight": "^7.12.13"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+        },
+        "@babel/highlight": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+          "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.12.11",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.0.tgz",
+      "integrity": "sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==",
+      "requires": {
+        "@babel/code-frame": "^7.12.13",
+        "@babel/generator": "^7.13.0",
+        "@babel/helper-function-name": "^7.12.13",
+        "@babel/helper-split-export-declaration": "^7.12.13",
+        "@babel/parser": "^7.13.0",
+        "@babel/types": "^7.13.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.19"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+          "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+          "requires": {
+            "@babel/highlight": "^7.12.13"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+        },
+        "@babel/highlight": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+          "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.12.11",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
+      "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
       "requires": {
         "@babel/helper-validator-identifier": "^7.12.11",
         "lodash": "^4.17.19",
@@ -536,95 +818,93 @@
       }
     },
     "@ew-did-registry/claims": {
-      "version": "0.0.1-alpha.827.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/claims/-/claims-0.0.1-alpha.827.0.tgz",
-      "integrity": "sha512-SIJIVFZn4HVq8RByQPKJoJM6/nlcwcwNrJSR9+87qKvlxBmrnJv17UBzo/MdfljaDzfHygW2WxKtU8mKW1BiUQ==",
+      "version": "0.1.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/claims/-/claims-0.1.0-alpha.0.tgz",
+      "integrity": "sha512-pN9zXoSro75SCKAH6kr4/LHLgXEUT4yM6gF252ZuJzF5Whb9tZ6GMNVKKKHj4UaISwiKJO8ksEPwBWQCUinkbA==",
       "requires": {
-        "@ew-did-registry/did": "0.0.1-alpha.632.0",
-        "@ew-did-registry/did-document": "0.0.1-alpha.827.0",
-        "@ew-did-registry/did-ethr-resolver": "0.0.1-alpha.827.0",
-        "@ew-did-registry/did-ipfs-store": "0.0.1-alpha.632.0",
-        "@ew-did-registry/did-resolver-interface": "0.0.1-alpha.827.0",
-        "@ew-did-registry/did-store-interface": "0.0.1-alpha.632.0",
-        "@ew-did-registry/jwt": "0.0.1-alpha.676.0",
-        "@ew-did-registry/keys": "0.0.1-alpha.632.0",
+        "@ew-did-registry/did": "0.1.0-alpha.0",
+        "@ew-did-registry/did-document": "0.1.0-alpha.0",
+        "@ew-did-registry/did-ethr-resolver": "0.1.0-alpha.0",
+        "@ew-did-registry/did-ipfs-store": "0.1.0-alpha.0",
+        "@ew-did-registry/did-resolver-interface": "0.1.0-alpha.0",
+        "@ew-did-registry/did-store-interface": "0.1.0-alpha.0",
+        "@ew-did-registry/jwt": "0.1.0-alpha.0",
+        "@ew-did-registry/keys": "0.1.0-alpha.0",
         "eciesjs": "^0.3.4",
         "sjcl-complete": "1.0.0"
       },
       "dependencies": {
         "@ew-did-registry/did": {
-          "version": "0.0.1-alpha.632.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.0.1-alpha.632.0.tgz",
-          "integrity": "sha512-JSpZdS7h8WdEr/w2nZ9P4+APvqOocMjWh+cjZZwViyV2t8/H/wJyyhJXmtcCArewHlojzIPWYtOHVXnFdcGTcg=="
+          "version": "0.1.0-alpha.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.1.0-alpha.0.tgz",
+          "integrity": "sha512-gmNhb03rMXHHu2lfHNGtb5ObId41iP2zVed4JRmkIOcTccsMatRRYEPbwet2vInzgC1A9b7XvQdYDER72d30Bw=="
         },
         "@ew-did-registry/did-document": {
-          "version": "0.0.1-alpha.827.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-document/-/did-document-0.0.1-alpha.827.0.tgz",
-          "integrity": "sha512-MB7R4/tRwbqzpqT71G0c+HCGhiCyKOyaD3jPLUYUcMDkzqz5MfHTufYG6HFJCM5lhpE81JwLYgVsp62bIV9NAw==",
+          "version": "0.1.0-alpha.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-document/-/did-document-0.1.0-alpha.0.tgz",
+          "integrity": "sha512-/HAkKqkxIlFEcdm8fKZtBzF00vje6bB5OOBdAScsw/5nTjSp0nxVpn7K3vlk8waGJniYC/4of5maaPwma9NxtA==",
           "requires": {
-            "@ew-did-registry/did": "0.0.1-alpha.632.0",
-            "@ew-did-registry/did-ethr-resolver": "0.0.1-alpha.827.0",
-            "@ew-did-registry/did-resolver-interface": "0.0.1-alpha.827.0",
-            "@ew-did-registry/keys": "0.0.1-alpha.632.0"
+            "@ew-did-registry/did": "0.1.0-alpha.0",
+            "@ew-did-registry/did-ethr-resolver": "0.1.0-alpha.0",
+            "@ew-did-registry/did-resolver-interface": "0.1.0-alpha.0",
+            "@ew-did-registry/keys": "0.1.0-alpha.0"
           }
         },
         "@ew-did-registry/did-ethr-resolver": {
-          "version": "0.0.1-alpha.827.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-ethr-resolver/-/did-ethr-resolver-0.0.1-alpha.827.0.tgz",
-          "integrity": "sha512-vU+BnaPhRU1779JN1Zzz9k+XFeXWBAi/Qgys78PIjamOrfUkqmhuUxbmbg3HdtIChfZDqvSa9G0m86DIHcrDJA==",
+          "version": "0.1.0-alpha.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-ethr-resolver/-/did-ethr-resolver-0.1.0-alpha.0.tgz",
+          "integrity": "sha512-Ue8kr0cllmQyJUv5tIuyAzbJqFWQiw+/eBzmCt6TAtGwhaWD+LEv7kM6peFavAFCDQ3A6u5vfZmn6Kj3LVISBw==",
           "requires": {
-            "@ew-did-registry/did": "0.0.1-alpha.632.0",
-            "@ew-did-registry/did-resolver-interface": "0.0.1-alpha.827.0",
-            "@ew-did-registry/keys": "0.0.1-alpha.632.0",
-            "@ew-did-registry/proxyidentity": "0.0.1-alpha.757.0",
-            "@walletconnect/client": "^1.3.1"
+            "@ew-did-registry/did": "0.1.0-alpha.0",
+            "@ew-did-registry/did-resolver-interface": "0.1.0-alpha.0",
+            "@ew-did-registry/keys": "0.1.0-alpha.0",
+            "@ew-did-registry/proxyidentity": "0.1.0-alpha.0"
           }
         },
         "@ew-did-registry/did-ipfs-store": {
-          "version": "0.0.1-alpha.632.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-ipfs-store/-/did-ipfs-store-0.0.1-alpha.632.0.tgz",
-          "integrity": "sha512-uShgOO8r/Ntb28UJltXV6Uz9vwDfI+a582Mlrlmkc24QXZfw4IDP5BdVnWjE4ecpg9P4gZkFzXVwok8Q0ZEifg==",
+          "version": "0.1.0-alpha.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-ipfs-store/-/did-ipfs-store-0.1.0-alpha.0.tgz",
+          "integrity": "sha512-HDvf2wyDMgo35K2Z9C9Kcsop7FXmn5ZAPCP5xdrKn6LuNsfyLak0KyJ3hiZApsfkH0GV8Nz7rfVW3bG700zoLQ==",
           "requires": {
-            "@ew-did-registry/did-store-interface": "0.0.1-alpha.632.0",
+            "@ew-did-registry/did-store-interface": "0.1.0-alpha.0",
             "bl": "^4.0.2",
             "ipfs-http-client": "^43.0.0"
           }
         },
         "@ew-did-registry/did-resolver-interface": {
-          "version": "0.0.1-alpha.827.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.0.1-alpha.827.0.tgz",
-          "integrity": "sha512-szxSdMie6os4LI3NwIej6BGnKeo1h2RN6D/Wz2UVx8Da6180+zKsrHjOyIw4IYRrSlcfaxBXMLsLgIWIhWuqHQ==",
+          "version": "0.1.0-alpha.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.1.0-alpha.0.tgz",
+          "integrity": "sha512-eOh5MpZxY6xuCp/XqJ9kUlg7+45H4RBjSxQpTIAKZx8P4Wm9lLlTLkJtb5XfZO6zIptBWvfWxpZX+rDMg/is5g==",
           "requires": {
-            "@ew-did-registry/did": "0.0.1-alpha.632.0"
+            "@ew-did-registry/did": "0.1.0-alpha.0"
           }
         },
         "@ew-did-registry/did-store-interface": {
-          "version": "0.0.1-alpha.632.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-store-interface/-/did-store-interface-0.0.1-alpha.632.0.tgz",
-          "integrity": "sha512-a8loweuifQBpN0Uf5Agva2XrRgnu4N3A3VquAyzvnSq0Bhe4yzZ98rGDtwSiTyhlaYRJUma++sMixY01TxGT3g=="
+          "version": "0.1.0-alpha.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-store-interface/-/did-store-interface-0.1.0-alpha.0.tgz",
+          "integrity": "sha512-onqszGknRdBkZySIlD4p3zsv5In9wD4HlvUEX6YPxJ2Mpo4RpaED43e9X64sYq9+P3dRU7QZms1WxwCWyDA9DA=="
         },
         "@ew-did-registry/keys": {
-          "version": "0.0.1-alpha.632.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.0.1-alpha.632.0.tgz",
-          "integrity": "sha512-Xp6IjomDnNNF3Ud/BsuFULz0mULK8XQkhUPcsAG5dXfRr/FfKqSPikd/tQN5IIoKUKej3TOtJ9gri6aGrZ04TA==",
+          "version": "0.1.0-alpha.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.1.0-alpha.0.tgz",
+          "integrity": "sha512-I0RA+cjgXYxEi2YDcx00/n2ytx9R8CcDUHz1FICp1FkyyV4mBePj8NmzaTzM5juHK8if98+VkVUfwYlp1H9sjw==",
           "requires": {
             "eciesjs": "^0.3.4",
             "elliptic": "^6.5.2"
           }
         },
         "@ew-did-registry/proxyidentity": {
-          "version": "0.0.1-alpha.757.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/proxyidentity/-/proxyidentity-0.0.1-alpha.757.0.tgz",
-          "integrity": "sha512-gCLt0tvEdF7Pat7mGZySVBPXnGDt0/FJcXpBdtVoIcAXpyJP4T12EBS3Mv64V8PtyHmXup0oya3Gc2bHj6wlmQ==",
+          "version": "0.1.0-alpha.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/proxyidentity/-/proxyidentity-0.1.0-alpha.0.tgz",
+          "integrity": "sha512-Je7LPXV/4TfgFgpqTNnp3y9ua9BVL/IWEmZqC22qbDJW/E/7aq2NEe6T38ql81T0cOe8YV5bcf32jeSQwyDYWQ==",
           "requires": {
-            "ethers": "4.0.45",
-            "web3": "1.2.6"
+            "ethers": "4.0.45"
           }
         },
         "bl": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.4.tgz",
-          "integrity": "sha512-7tdr4EpSd7jJ6tuQ21vu2ke8w7pNEstzj1O8wwq6sNNzO3UDi5MA8Gny/gquCj7r2C6fHudg8tKRGyjRgmvNxQ==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
           "requires": {
             "buffer": "^5.5.0",
             "inherits": "^2.0.4",
@@ -767,11 +1047,11 @@
       "integrity": "sha512-c93BJc0BvXVl8yvxz4+T9vUBguyuU1FV8sLS7SH7H5E3b9a7M20o+QDOE9c4xVhkbhTdhtj2T0zEnuXHqIt9uA=="
     },
     "@ew-did-registry/jwt": {
-      "version": "0.0.1-alpha.676.0",
-      "resolved": "https://registry.npmjs.org/@ew-did-registry/jwt/-/jwt-0.0.1-alpha.676.0.tgz",
-      "integrity": "sha512-YSnhxG4x6eRF3Fbj3ctC1KntWfjcvCEILCI5SwHT7CRHxcauHTkWSNHnk68SkTDIIjzUaTWeC+OfA4ZymKt6Zw==",
+      "version": "0.1.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/jwt/-/jwt-0.1.0-alpha.0.tgz",
+      "integrity": "sha512-koY9ym+sXEODuzCxaKuYyeLKaJHnvW5KbVsTcb42yofUMYw1Yu5PgJxxfQuskpjDXq0do8ypcA7sxgRT85sFhg==",
       "requires": {
-        "@ew-did-registry/keys": "0.0.1-alpha.632.0",
+        "@ew-did-registry/keys": "0.1.0-alpha.0",
         "@types/promise.allsettled": "^1.0.3",
         "base64url": "^3.0.1",
         "ethereumjs-util": "^7.0.5",
@@ -781,25 +1061,33 @@
       },
       "dependencies": {
         "@ew-did-registry/keys": {
-          "version": "0.0.1-alpha.632.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.0.1-alpha.632.0.tgz",
-          "integrity": "sha512-Xp6IjomDnNNF3Ud/BsuFULz0mULK8XQkhUPcsAG5dXfRr/FfKqSPikd/tQN5IIoKUKej3TOtJ9gri6aGrZ04TA==",
+          "version": "0.1.0-alpha.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.1.0-alpha.0.tgz",
+          "integrity": "sha512-I0RA+cjgXYxEi2YDcx00/n2ytx9R8CcDUHz1FICp1FkyyV4mBePj8NmzaTzM5juHK8if98+VkVUfwYlp1H9sjw==",
           "requires": {
             "eciesjs": "^0.3.4",
             "elliptic": "^6.5.2"
           }
         },
+        "@types/bn.js": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
+          "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
         "bn.js": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
-          "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ=="
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
         },
         "ethereumjs-util": {
-          "version": "7.0.8",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.0.8.tgz",
-          "integrity": "sha512-JJt7tDpCAmDPw/sGoFYeq0guOVqT3pTE9xlEbBmc/nlCij3JRCoS2c96SQ6kXVHOT3xWUNLDm5QCJLQaUnVAtQ==",
+          "version": "7.0.9",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.0.9.tgz",
+          "integrity": "sha512-cRqvYYKJoitq6vMKMf8pXeVwvTrX+dRD0JwHaYqm8jvogK14tqIoCWH/KUHcRwnVxVXEYF/o6pup5jRG4V0xzg==",
           "requires": {
-            "@types/bn.js": "^4.11.3",
+            "@types/bn.js": "^5.1.0",
             "bn.js": "^5.1.2",
             "create-hash": "^1.1.2",
             "ethereum-cryptography": "^0.1.3",
@@ -878,20 +1166,189 @@
         }
       }
     },
+    "@gnosis.pm/safe-apps-sdk": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@gnosis.pm/safe-apps-sdk/-/safe-apps-sdk-1.0.3.tgz",
+      "integrity": "sha512-77c6lg4SfCbQtMjgB2vVPKQglUCOjSpwweNeoD4m0c5hnd5lFg0Dlcc45LwtcUL8j5XhDf+aBxT8LDD+XGDSNw==",
+      "requires": {
+        "semver": "^7.3.2",
+        "web3-core": "^1.3.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.20.6",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.6.tgz",
+          "integrity": "sha512-sRVq8d+ApGslmkE9e3i+D3gFGk7aZHAT+G4cIpIEdLJYPsWiSPwcAnJEjddLQQDqV3Ra2jOclX/Sv6YrvGYiWA=="
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "eventemitter3": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
+        },
+        "oboe": {
+          "version": "2.1.5",
+          "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.5.tgz",
+          "integrity": "sha1-VVQoTFQ6ImbXo48X4HOCH73jk80=",
+          "requires": {
+            "http-https": "^1.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "web3-core": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.3.4.tgz",
+          "integrity": "sha512-7OJu46RpCEfTerl+gPvHXANR2RkLqAfW7l2DAvQ7wN0pnCzl9nEfdgW6tMhr31k3TR2fWucwKzCyyxMGzMHeSA==",
+          "requires": {
+            "@types/bn.js": "^4.11.5",
+            "@types/node": "^12.12.6",
+            "bignumber.js": "^9.0.0",
+            "web3-core-helpers": "1.3.4",
+            "web3-core-method": "1.3.4",
+            "web3-core-requestmanager": "1.3.4",
+            "web3-utils": "1.3.4"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.3.4.tgz",
+          "integrity": "sha512-n7BqDalcTa1stncHMmrnFtyTgDhX5Fy+avNaHCf6qcOP2lwTQC8+mdHVBONWRJ6Yddvln+c8oY/TAaB6PzWK0A==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-eth-iban": "1.3.4",
+            "web3-utils": "1.3.4"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.3.4.tgz",
+          "integrity": "sha512-JxmQrujsAWYRRN77P/RY7XuZDCzxSiiQJrgX/60Lfyf7FF1Y0le4L/UMCi7vUJnuYkbU1Kfl9E0udnqwyPqlvQ==",
+          "requires": {
+            "@ethersproject/transactions": "^5.0.0-beta.135",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.3.4",
+            "web3-core-promievent": "1.3.4",
+            "web3-core-subscriptions": "1.3.4",
+            "web3-utils": "1.3.4"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.3.4.tgz",
+          "integrity": "sha512-V61dZIeBwogg6hhZZUt0qL9hTp1WDhnsdjP++9fhTDr4vy/Gz8T5vibqT2LLg6lQC8i+Py33yOpMeMNjztaUaw==",
+          "requires": {
+            "eventemitter3": "4.0.4"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.3.4.tgz",
+          "integrity": "sha512-xriouCrhVnVDYQ04TZXdEREZm0OOJzkSEsoN5bu4JYsA6e/HzROeU+RjDpMUxFMzN4wxmFZ+HWbpPndS3QwMag==",
+          "requires": {
+            "underscore": "1.9.1",
+            "util": "^0.12.0",
+            "web3-core-helpers": "1.3.4",
+            "web3-providers-http": "1.3.4",
+            "web3-providers-ipc": "1.3.4",
+            "web3-providers-ws": "1.3.4"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.3.4.tgz",
+          "integrity": "sha512-drVHVDxh54hv7xmjIm44g4IXjfGj022fGw4/meB5R2D8UATFI40F73CdiBlyqk3DysP9njDOLTJFSQvEkLFUOg==",
+          "requires": {
+            "eventemitter3": "4.0.4",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.3.4"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.3.4.tgz",
+          "integrity": "sha512-Y7/hLjVvIN/OhaAyZ8L/hxbTqVX6AFTl2RwUXR6EEU9oaLydPcMjAx/Fr8mghUvQS3QJSr+UGubP3W4SkyNiYw==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "web3-utils": "1.3.4"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.3.4.tgz",
+          "integrity": "sha512-aIg/xHXvxpqpFU70sqfp+JC3sGkLfAimRKTUhG4oJZ7U+tTcYTHoxBJj+4A3Id4JAoKiiv0k1/qeyQ8f3rMC3g==",
+          "requires": {
+            "web3-core-helpers": "1.3.4",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.3.4.tgz",
+          "integrity": "sha512-E0CvXEJElr/TIlG1YfJeO3Le5NI/4JZM+1SsEdiPIfBUAJN18oOoum138EBGKv5+YaLKZUtUuJSXWjIIOR/0Ig==",
+          "requires": {
+            "oboe": "2.1.5",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.3.4"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.3.4.tgz",
+          "integrity": "sha512-WBd9hk2fUAdrbA3kUyUk94ZeILtE6txLeoVVvIKAw2bPegx+RjkLyxC1Du0oceKgQ/qQWod8CCzl1E/GgTP+MQ==",
+          "requires": {
+            "eventemitter3": "4.0.4",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.3.4",
+            "websocket": "^1.0.32"
+          }
+        },
+        "web3-utils": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.4.tgz",
+          "integrity": "sha512-/vC2v0MaZNpWooJfpRw63u0Y3ag2gNjAWiLtMSL6QQLmCqCy4SQIndMt/vRyx0uMoeGt1YTwSXEcHjUzOhLg0A==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
     "@json-rpc-tools/types": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/types/-/types-1.6.1.tgz",
-      "integrity": "sha512-Fg8Dke0+K92cZaWm0/vFIZgNdHftEI5GXbgT2rwUmmo/GrjlXJn5cPRghq5ee+QGTeZvWcjYmqdwrdGbTGBCMw==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/types/-/types-1.6.4.tgz",
+      "integrity": "sha512-DHtnvlIFN8YUun38Sy9SaRdV/BsUMFM5bAABDsb/iPGLfPHOMKoAyuPOwEqQ2vgtc9ayTcQ2546OPTQ92IzJ/g==",
       "requires": {
         "keyvaluestorage-interface": "^1.0.0"
       }
     },
     "@json-rpc-tools/utils": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/utils/-/utils-1.5.7.tgz",
-      "integrity": "sha512-AE7p5p15Lgu/L6onIaQfvIEUHD3U95hmOBNp3rdIe/lTjZIZrwm+CUiA/UAa+4QqwlG74Ri4fKbm+uriW5HaZA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-cNwP4QapAls+xATU8zLLqPYa9qCbgwEyWEK7vE1oH91b3LfbUYwHtiWZ1+rv0X/mh/9cWNTo2Oi2Sah/QX0WwA==",
       "requires": {
-        "@json-rpc-tools/types": "^1.5.7"
+        "@json-rpc-tools/types": "^1.6.1"
       }
     },
     "@metamask/detect-provider": {
@@ -899,15 +1356,20 @@
       "resolved": "https://registry.npmjs.org/@metamask/detect-provider/-/detect-provider-1.2.0.tgz",
       "integrity": "sha512-ocA76vt+8D0thgXZ7LxFPyqw3H7988qblgzddTDA6B8a/yU0uKV42QR/DhA+Jh11rJjxW0jKvwb5htA6krNZDQ=="
     },
+    "@metamask/safe-event-emitter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz",
+      "integrity": "sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q=="
+    },
     "@pedrouid/iso-crypto": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@pedrouid/iso-crypto/-/iso-crypto-1.0.0.tgz",
-      "integrity": "sha512-gSz/81Cz2n9p1RHalxN8STtOHg6Dqa+l2Phz36GptpneAcAwOzPmty7FSg58htF4u9V44vEXsc7L8V9ze9j4Xg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pedrouid/iso-crypto/-/iso-crypto-1.1.0.tgz",
+      "integrity": "sha512-twi+tW67XT0BSOv4rsegnGo4TQMhfFswS/GY3KhrjFiNw3z9x+cMkfO+itNe1JZghQxsxHuhifvfsnG814g1hQ==",
       "requires": {
+        "@pedrouid/iso-random": "^1.1.0",
         "aes-js": "^3.1.2",
         "enc-utils": "^3.0.0",
-        "hash.js": "^1.1.7",
-        "randombytes": "^2.1.0"
+        "hash.js": "^1.1.7"
       },
       "dependencies": {
         "aes-js": {
@@ -915,6 +1377,15 @@
           "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
           "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ=="
         }
+      }
+    },
+    "@pedrouid/iso-random": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pedrouid/iso-random/-/iso-random-1.1.0.tgz",
+      "integrity": "sha512-U8P2qdbvyU5aom0036dkpp0C9c8pgW1SNhAo8+zPDzgmKA58Hl6dc+ZkQXkE9aHrzN6v/0w+409JMjSYwx5tVw==",
+      "requires": {
+        "enc-utils": "^3.0.0",
+        "randombytes": "^2.1.0"
       }
     },
     "@shareandcharge/ocn-notary": {
@@ -1191,34 +1662,46 @@
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
     },
-    "@walletconnect/client": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/client/-/client-1.3.4.tgz",
-      "integrity": "sha512-CRV4npHVNb7D1BVRRCiVQ3YBGNp7lEq8Ikkrgg1eWDAXCUNTtzAhmGo6uCzxjh6cpvfiHQNjZbShrqP+d286QQ==",
+    "@walletconnect/browser-utils": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/browser-utils/-/browser-utils-1.4.0.tgz",
+      "integrity": "sha512-2oLQGaQ53bJvoToYG17XGf8palfbNF4ZdSvBKmEYX1ac9NnDetEPBfryz0Ij2s4f9o9XfVKFO7+HPLzm2ayMMw==",
       "requires": {
-        "@walletconnect/core": "^1.3.4",
-        "@walletconnect/iso-crypto": "^1.3.4",
-        "@walletconnect/types": "^1.3.4",
-        "@walletconnect/utils": "^1.3.4"
+        "@walletconnect/types": "^1.4.0",
+        "detect-browser": "5.2.0",
+        "safe-json-utils": "1.0.0",
+        "window-getters": "1.0.0",
+        "window-metadata": "1.0.0"
+      }
+    },
+    "@walletconnect/client": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/client/-/client-1.4.0.tgz",
+      "integrity": "sha512-lg3JFCuECCvZEl7BpOztNtnStOmOpGqXuSIhisnaEtqUgHdopH275Rz5jU736X5uS+7VExU6LOIWKNPPXlY2ZQ==",
+      "requires": {
+        "@walletconnect/core": "^1.4.0",
+        "@walletconnect/iso-crypto": "^1.4.0",
+        "@walletconnect/types": "^1.4.0",
+        "@walletconnect/utils": "^1.4.0"
       }
     },
     "@walletconnect/core": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-1.3.4.tgz",
-      "integrity": "sha512-CwAiQYT7oo3MwrYIOoLSce8iaZT5mNwVavc4s3S2TvkxoVc+ORywaXvUDavgFfWqW0P4gg4tO+e8QPD2Mxfm1w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-1.4.0.tgz",
+      "integrity": "sha512-0rPfgSAcdCHG/JcEUgLAJ6wnQOsd7AiBEAUv7d71ViORu1gKrXm8mWKpWnPkPV53IH+oRVVP0pAGEpwo7f+Bdw==",
       "requires": {
-        "@walletconnect/socket-transport": "^1.3.4",
-        "@walletconnect/types": "^1.3.4",
-        "@walletconnect/utils": "^1.3.4"
+        "@walletconnect/socket-transport": "^1.4.0",
+        "@walletconnect/types": "^1.4.0",
+        "@walletconnect/utils": "^1.4.0"
       }
     },
     "@walletconnect/http-connection": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/http-connection/-/http-connection-1.3.4.tgz",
-      "integrity": "sha512-eMNlR8ye5CHQxQf7gIfZ9IZAZyhDFISw3qnldibjE4FHULbTJVUwiFmUdr/4pY6TYwcr/ePe1AzRqJt8Vvt07g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/http-connection/-/http-connection-1.4.0.tgz",
+      "integrity": "sha512-HIYrgzz/Fagwoyco6RsnxAD9pFLdt0cp+g+Rhw770QIhax0PjzpiC+IcLcYqVDFcCJwss6pZFlyPu7AAK67VDw==",
       "requires": {
-        "@walletconnect/types": "^1.3.4",
-        "@walletconnect/utils": "^1.3.4",
+        "@walletconnect/types": "^1.4.0",
+        "@walletconnect/utils": "^1.4.0",
         "eventemitter3": "4.0.7",
         "xhr2-cookies": "1.1.0"
       },
@@ -1231,38 +1714,39 @@
       }
     },
     "@walletconnect/iso-crypto": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/iso-crypto/-/iso-crypto-1.3.4.tgz",
-      "integrity": "sha512-LHH3x+ISyIzF+5RYmQxd9FesNSCfQvRlCmEFjBp0NjlqRr0q1hRD4kj71+B7B0W+5a9zwS5FkkKJ2gaxxNntdg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/iso-crypto/-/iso-crypto-1.4.0.tgz",
+      "integrity": "sha512-pd5N6brECiRCp9A7skW1gL/fw24vjzy8zQJvn75GFRcuYcHNgpQwFOAq5OvaZt6/9wBIL1rVZ9QdBpyZ+EX85w==",
       "requires": {
         "@pedrouid/iso-crypto": "^1.0.0",
-        "@walletconnect/types": "^1.3.4",
-        "@walletconnect/utils": "^1.3.4"
+        "@walletconnect/types": "^1.4.0",
+        "@walletconnect/utils": "^1.4.0"
       }
     },
     "@walletconnect/mobile-registry": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/mobile-registry/-/mobile-registry-1.3.4.tgz",
-      "integrity": "sha512-TiTs6rQmXLfOQq0/t1ajc59GX8XbqyoAHFRYeW6shsQuPz7lD8Z2+ERpjExNhyW07/x2rPnrap+WxAJWLGRUkA=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/mobile-registry/-/mobile-registry-1.4.0.tgz",
+      "integrity": "sha512-ZtKRio4uCZ1JUF7LIdecmZt7FOLnX72RPSY7aUVu7mj7CSfxDwUn6gBuK6WGtH+NZCldBqDl5DenI5fFSvkKYw=="
     },
     "@walletconnect/qrcode-modal": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/qrcode-modal/-/qrcode-modal-1.3.4.tgz",
-      "integrity": "sha512-8qByfDeGgK8RRXM2JUym0oY0fnccEtX5j2/zGk3JmzlNL7RwnCvYHcnAIwzvst/lFYty/5r2YQGdUbwAhGGQnQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/qrcode-modal/-/qrcode-modal-1.4.0.tgz",
+      "integrity": "sha512-FOov70va04sOReI9ijGPbYexXtNWS7VZPlSEv7vHLq5ufcghh0sPsl5MfO6wvyNqpSJERbGoTmaHLSMR7LjpFg==",
       "requires": {
-        "@walletconnect/mobile-registry": "^1.3.4",
-        "@walletconnect/types": "^1.3.4",
-        "@walletconnect/utils": "^1.3.4",
+        "@walletconnect/browser-utils": "^1.4.0",
+        "@walletconnect/mobile-registry": "^1.4.0",
+        "@walletconnect/types": "^1.4.0",
         "preact": "10.4.1",
         "qrcode": "1.4.4"
       }
     },
     "@walletconnect/socket-transport": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/socket-transport/-/socket-transport-1.3.4.tgz",
-      "integrity": "sha512-zjh3gQ0B6i5QyKSsQFAXDvF+Wttl/OVf2BiHKcHi9XSH+lFKJJeXDACmEja3ujRMEBw4U6nr/iH2X2kHeHkP+w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/socket-transport/-/socket-transport-1.4.0.tgz",
+      "integrity": "sha512-X/7Hm+4w0d9fn0xf8adXetlHxmvpyw1cvUPHSCPxEzC+xACdZE1Q/dveDfEb/RaWlv7Z3IQoagVSCN/3xzkyYQ==",
       "requires": {
-        "@walletconnect/types": "^1.3.4",
+        "@walletconnect/types": "^1.4.0",
+        "@walletconnect/utils": "^1.4.0",
         "ws": "7.3.0"
       },
       "dependencies": {
@@ -1274,25 +1758,22 @@
       }
     },
     "@walletconnect/types": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.3.4.tgz",
-      "integrity": "sha512-XK9cogoYdMkk8UcJIBi23iMazYdFLll0MeR10sjVY2rc1twqQ/8oiJHw8u8o1m5Qdw3Zxm30UrgBebPvcv9m5g=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.4.0.tgz",
+      "integrity": "sha512-aCeuVzIos3VsRIK+/nnk8WHAftQNVOLUeWOTZoClOOGFJk5HpaPNfyIHJ+hjU4VXh/3YuN0yqnCeMWVjKlQ3nw=="
     },
     "@walletconnect/utils": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.3.4.tgz",
-      "integrity": "sha512-AI/U5tvG7UfyLwTpo5hGL5ZFV31ypk/cG2MUOGoUYKfjKhyQcxX+wc6kXv2S+nBdS5aFgCS1aT9qHcbAIfOFHw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.4.0.tgz",
+      "integrity": "sha512-MFUKROV/TQKj6J95uNW0s04MU/yhl6wohZh5LwtKbFKIY2tsba+qM2miEXMo9fMOpxq/HnjBsVVVTZT9bSeIRw==",
       "requires": {
-        "@json-rpc-tools/utils": "1.5.7",
-        "@walletconnect/types": "^1.3.4",
+        "@json-rpc-tools/utils": "1.6.1",
+        "@walletconnect/browser-utils": "^1.4.0",
+        "@walletconnect/types": "^1.4.0",
         "bn.js": "4.11.8",
-        "detect-browser": "5.1.0",
         "enc-utils": "3.0.0",
         "js-sha3": "0.8.0",
-        "query-string": "6.13.5",
-        "safe-json-utils": "1.0.0",
-        "window-getters": "1.0.0",
-        "window-metadata": "1.0.0"
+        "query-string": "6.13.5"
       },
       "dependencies": {
         "bn.js": {
@@ -1445,6 +1926,11 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "array-filter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
+      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
+    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -1513,6 +1999,14 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
+    "async-mutex": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.2.6.tgz",
+      "integrity": "sha512-Hs4R+4SPgamu6rSGW8C7cV9gaWUKEHykfzCCvIRuaVv636Ju10ZdeUbvb4TBEW0INuq2DHZqXbK4Nd3yG4RaRw==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1523,10 +2017,13 @@
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
-    "await-semaphore": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/await-semaphore/-/await-semaphore-0.1.3.tgz",
-      "integrity": "sha512-d1W2aNSYcz/sxYO4pMGX9vq65qOTu0P800epMud+6cYYX0QcT7zyqcxec3VWzpgvdXo57UWmVbZpLMjX2m1I7Q=="
+    "available-typed-arrays": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
+      "integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
+      "requires": {
+        "array-filter": "^1.0.0"
+      }
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -1544,6 +2041,33 @@
       "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "requires": {
         "follow-redirects": "^1.10.0"
+      }
+    },
+    "babel-plugin-polyfill-corejs2": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.1.10.tgz",
+      "integrity": "sha512-DO95wD4g0A8KRaHKi0D51NdGXzvpqVLnLu5BTvDlpqUEpTmeEtypgC1xqesORaWmiUOQI14UHKlzNd9iZ2G3ZA==",
+      "requires": {
+        "@babel/compat-data": "^7.13.0",
+        "@babel/helper-define-polyfill-provider": "^0.1.5",
+        "semver": "^6.1.1"
+      }
+    },
+    "babel-plugin-polyfill-corejs3": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.1.7.tgz",
+      "integrity": "sha512-u+gbS9bbPhZWEeyy1oR/YaaSpod/KDT07arZHb80aTpl8H5ZBq+uN1nN9/xtX7jQyfLdPfoqI4Rue/MQSWJquw==",
+      "requires": {
+        "@babel/helper-define-polyfill-provider": "^0.1.5",
+        "core-js-compat": "^3.8.1"
+      }
+    },
+    "babel-plugin-polyfill-regenerator": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.1.6.tgz",
+      "integrity": "sha512-OUrYG9iKPKz8NxswXbRAdSwF0GhRdIEMTloQATJi4bDuFqrXaXcCUT/VGNrr8pBcjMh1RxZ7Xt9cytVJTJfvMg==",
+      "requires": {
+        "@babel/helper-define-polyfill-provider": "^0.1.5"
       }
     },
     "backoff": {
@@ -1804,6 +2328,18 @@
         }
       }
     },
+    "browserslist": {
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
+      "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+      "requires": {
+        "caniuse-lite": "^1.0.30001181",
+        "colorette": "^1.2.1",
+        "electron-to-chromium": "^1.3.649",
+        "escalade": "^3.1.1",
+        "node-releases": "^1.1.70"
+      }
+    },
     "bs58": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
@@ -1880,6 +2416,14 @@
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
     },
+    "bufferutil": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.3.tgz",
+      "integrity": "sha512-yEYTwGndELGvfXsImMBLop58eaGW+YdONi1fNjTINSY98tmMmFijBG6WXgdkfuLNt4imzQNtIE+eBp1PVpMCSw==",
+      "requires": {
+        "node-gyp-build": "^4.2.0"
+      }
+    },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -1933,6 +2477,11 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001204",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001204.tgz",
+      "integrity": "sha512-JUdjWpcxfJ9IPamy2f5JaRDCaqJOxDzOSKtbdx4rH9VivMd1vIzoPumsJa9LoMIi4Fx2BV2KZOxWhNkBjaYivQ=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -2086,6 +2635,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "colorette": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
+    },
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -2138,6 +2692,22 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
       "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
+    },
+    "core-js-compat": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.9.1.tgz",
+      "integrity": "sha512-jXAirMQxrkbiiLsCx9bQPJFA6llDadKMpYrBJQJ3/c4/vsPP/fAf29h24tviRlvwUL6AmY5CHLu2GvjuYviQqA==",
+      "requires": {
+        "browserslist": "^4.16.3",
+        "semver": "7.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A=="
+        }
+      }
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -2410,9 +2980,9 @@
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "detect-browser": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.1.0.tgz",
-      "integrity": "sha512-WKa9p+/MNwmTiS+V2AS6eGxic+807qvnV3hC+4z2GTY+F42h1n8AynVTMMc4EJBC32qMs6yjOTpeDEQQt/AVqQ=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.2.0.tgz",
+      "integrity": "sha512-tr7XntDAu50BVENgQfajMLzacmSe34D+qZc4zjnniz0ZVuw/TZcLcyxHQjYpJTM36sGEkZZlYLnIM1hH7alTMA=="
     },
     "diff": {
       "version": "4.0.2",
@@ -2476,6 +3046,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "electron-to-chromium": {
+      "version": "1.3.693",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.693.tgz",
+      "integrity": "sha512-vUdsE8yyeu30RecppQtI+XTz2++LWLVEIYmzeCaCRLSdtKZ2eXqdJcrs85KwLiPOPVc6PELgWyXBsfqIvzGZag=="
     },
     "elliptic": {
       "version": "6.5.3",
@@ -2558,24 +3133,26 @@
       }
     },
     "es-abstract": {
-      "version": "1.18.0-next.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.2.tgz",
-      "integrity": "sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+      "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2",
+        "get-intrinsic": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1",
-        "is-callable": "^1.2.2",
+        "has-symbols": "^1.0.2",
+        "is-callable": "^1.2.3",
         "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.1",
+        "is-regex": "^1.1.2",
+        "is-string": "^1.0.5",
         "object-inspect": "^1.9.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.3",
-        "string.prototype.trimstart": "^1.0.3"
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.0"
       }
     },
     "es-array-method-boxes-properly": {
@@ -2643,6 +3220,11 @@
         "d": "^1.0.1",
         "ext": "^1.1.2"
       }
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -2732,16 +3314,16 @@
       }
     },
     "eth-json-rpc-filters": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eth-json-rpc-filters/-/eth-json-rpc-filters-4.2.1.tgz",
-      "integrity": "sha512-tPfohezq8mSmwa47xvq6PGzBDLZ0njWJMB1J+OPuv+n+1WkWDlf3l3tqJXpq96RxhrzK2q7wiweRS5aGIzpq4Q==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/eth-json-rpc-filters/-/eth-json-rpc-filters-4.2.2.tgz",
+      "integrity": "sha512-DGtqpLU7bBg63wPMWg1sCpkKCf57dJ+hj/k3zF26anXMzkmtSBDExL8IhUu7LUd34f0Zsce3PYNO2vV2GaTzaw==",
       "requires": {
-        "await-semaphore": "^0.1.3",
+        "@metamask/safe-event-emitter": "^2.0.0",
+        "async-mutex": "^0.2.6",
         "eth-json-rpc-middleware": "^6.0.0",
         "eth-query": "^2.1.2",
-        "json-rpc-engine": "^5.3.0",
-        "lodash.flatmap": "^4.5.0",
-        "safe-event-emitter": "^1.0.1"
+        "json-rpc-engine": "^6.1.0",
+        "pify": "^5.0.0"
       },
       "dependencies": {
         "eth-json-rpc-middleware": {
@@ -2760,6 +3342,22 @@
             "node-fetch": "^2.6.1",
             "pify": "^3.0.0",
             "safe-event-emitter": "^1.0.1"
+          },
+          "dependencies": {
+            "json-rpc-engine": {
+              "version": "5.4.0",
+              "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-5.4.0.tgz",
+              "integrity": "sha512-rAffKbPoNDjuRnXkecTjnsE3xLLrb00rEkdgalINhaYVYIxDwWtvYBr9UFbhTvPB1B2qUOLoFd/cV6f4Q7mh7g==",
+              "requires": {
+                "eth-rpc-errors": "^3.0.0",
+                "safe-event-emitter": "^1.0.1"
+              }
+            },
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+            }
           }
         },
         "ethereumjs-util": {
@@ -2777,9 +3375,9 @@
           }
         },
         "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
+          "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA=="
         }
       }
     },
@@ -2792,6 +3390,17 @@
         "eth-rpc-errors": "^3.0.0",
         "json-rpc-engine": "^5.1.3",
         "node-fetch": "^2.6.0"
+      },
+      "dependencies": {
+        "json-rpc-engine": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-5.4.0.tgz",
+          "integrity": "sha512-rAffKbPoNDjuRnXkecTjnsE3xLLrb00rEkdgalINhaYVYIxDwWtvYBr9UFbhTvPB1B2qUOLoFd/cV6f4Q7mh7g==",
+          "requires": {
+            "eth-rpc-errors": "^3.0.0",
+            "safe-event-emitter": "^1.0.1"
+          }
+        }
       }
     },
     "eth-json-rpc-middleware": {
@@ -2849,6 +3458,15 @@
             "ethjs-util": "^0.1.3",
             "rlp": "^2.0.0",
             "safe-buffer": "^5.1.1"
+          }
+        },
+        "json-rpc-engine": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-5.4.0.tgz",
+          "integrity": "sha512-rAffKbPoNDjuRnXkecTjnsE3xLLrb00rEkdgalINhaYVYIxDwWtvYBr9UFbhTvPB1B2qUOLoFd/cV6f4Q7mh7g==",
+          "requires": {
+            "eth-rpc-errors": "^3.0.0",
+            "safe-event-emitter": "^1.0.1"
           }
         },
         "pify": {
@@ -2963,7 +3581,7 @@
       }
     },
     "ethereumjs-abi": {
-      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1ce6a1d64235fabe2aaf827fd606def55693508f",
+      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1a27c59c15ab1e95ee8e5c4ed6ad814c49cc439e",
       "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
       "requires": {
         "bn.js": "^4.11.8",
@@ -3189,9 +3807,9 @@
       "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
     },
     "events": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
-      "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
     "evp_bytestokey": {
       "version": "1.0.3",
@@ -3375,9 +3993,14 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
-      "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA=="
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
+      "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA=="
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -3527,6 +4150,11 @@
         "process": "~0.5.1"
       }
     },
+    "globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+    },
     "got": {
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
@@ -3578,6 +4206,11 @@
         "function-bind": "^1.1.1"
       }
     },
+    "has-bigints": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
+    },
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3590,9 +4223,9 @@
       "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
     },
     "has-symbols": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
     },
     "has-to-string-tag-x": {
       "version": "1.4.1",
@@ -3694,20 +4327,21 @@
       }
     },
     "iam-client-lib": {
-      "version": "2.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/iam-client-lib/-/iam-client-lib-2.0.0-alpha.3.tgz",
-      "integrity": "sha512-XmzZCH45flh2X37KPfzGhu3+fNVJpRiwUVt30WmqMED4OmwBd/0fe402n7+19Ape/KJ+HhlVpEGlGEujlMPrdQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/iam-client-lib/-/iam-client-lib-2.0.0.tgz",
+      "integrity": "sha512-1krQM7+v9WPCzJvsLNthvnDdNk8TigYWM7iMjGLJiDhHoanUzZbA4iQ7ocYvTx4sBJQ9ZASEfACrKDSmt7rt4g==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@ensdomains/ens": "^0.4.5",
         "@ensdomains/resolver": "^0.2.4",
-        "@ew-did-registry/claims": "0.0.1-alpha.827.0",
-        "@ew-did-registry/did": "0.0.1-alpha.632.0",
-        "@ew-did-registry/did-document": "0.0.1-alpha.827.0",
-        "@ew-did-registry/did-ethr-resolver": "0.0.1-alpha.827.0",
-        "@ew-did-registry/did-resolver-interface": "0.0.1-alpha.827.0",
-        "@ew-did-registry/jwt": "0.0.1-alpha.676.0",
-        "@ew-did-registry/keys": "0.0.1-alpha.632.0",
+        "@ew-did-registry/claims": "0.1.0-alpha.0",
+        "@ew-did-registry/did": "0.1.0-alpha.0",
+        "@ew-did-registry/did-document": "0.1.0-alpha.0",
+        "@ew-did-registry/did-ethr-resolver": "0.1.0-alpha.0",
+        "@ew-did-registry/did-resolver-interface": "0.1.0-alpha.0",
+        "@ew-did-registry/jwt": "0.1.0-alpha.0",
+        "@ew-did-registry/keys": "0.1.0-alpha.0",
+        "@gnosis.pm/safe-apps-sdk": "1.0.3",
         "@metamask/detect-provider": "^1.2.0",
         "@walletconnect/web3-provider": "1.0.0-rc.4",
         "axios": "^0.21.1",
@@ -3723,57 +4357,55 @@
       },
       "dependencies": {
         "@ew-did-registry/did": {
-          "version": "0.0.1-alpha.632.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.0.1-alpha.632.0.tgz",
-          "integrity": "sha512-JSpZdS7h8WdEr/w2nZ9P4+APvqOocMjWh+cjZZwViyV2t8/H/wJyyhJXmtcCArewHlojzIPWYtOHVXnFdcGTcg=="
+          "version": "0.1.0-alpha.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.1.0-alpha.0.tgz",
+          "integrity": "sha512-gmNhb03rMXHHu2lfHNGtb5ObId41iP2zVed4JRmkIOcTccsMatRRYEPbwet2vInzgC1A9b7XvQdYDER72d30Bw=="
         },
         "@ew-did-registry/did-document": {
-          "version": "0.0.1-alpha.827.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-document/-/did-document-0.0.1-alpha.827.0.tgz",
-          "integrity": "sha512-MB7R4/tRwbqzpqT71G0c+HCGhiCyKOyaD3jPLUYUcMDkzqz5MfHTufYG6HFJCM5lhpE81JwLYgVsp62bIV9NAw==",
+          "version": "0.1.0-alpha.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-document/-/did-document-0.1.0-alpha.0.tgz",
+          "integrity": "sha512-/HAkKqkxIlFEcdm8fKZtBzF00vje6bB5OOBdAScsw/5nTjSp0nxVpn7K3vlk8waGJniYC/4of5maaPwma9NxtA==",
           "requires": {
-            "@ew-did-registry/did": "0.0.1-alpha.632.0",
-            "@ew-did-registry/did-ethr-resolver": "0.0.1-alpha.827.0",
-            "@ew-did-registry/did-resolver-interface": "0.0.1-alpha.827.0",
-            "@ew-did-registry/keys": "0.0.1-alpha.632.0"
+            "@ew-did-registry/did": "0.1.0-alpha.0",
+            "@ew-did-registry/did-ethr-resolver": "0.1.0-alpha.0",
+            "@ew-did-registry/did-resolver-interface": "0.1.0-alpha.0",
+            "@ew-did-registry/keys": "0.1.0-alpha.0"
           }
         },
         "@ew-did-registry/did-ethr-resolver": {
-          "version": "0.0.1-alpha.827.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-ethr-resolver/-/did-ethr-resolver-0.0.1-alpha.827.0.tgz",
-          "integrity": "sha512-vU+BnaPhRU1779JN1Zzz9k+XFeXWBAi/Qgys78PIjamOrfUkqmhuUxbmbg3HdtIChfZDqvSa9G0m86DIHcrDJA==",
+          "version": "0.1.0-alpha.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-ethr-resolver/-/did-ethr-resolver-0.1.0-alpha.0.tgz",
+          "integrity": "sha512-Ue8kr0cllmQyJUv5tIuyAzbJqFWQiw+/eBzmCt6TAtGwhaWD+LEv7kM6peFavAFCDQ3A6u5vfZmn6Kj3LVISBw==",
           "requires": {
-            "@ew-did-registry/did": "0.0.1-alpha.632.0",
-            "@ew-did-registry/did-resolver-interface": "0.0.1-alpha.827.0",
-            "@ew-did-registry/keys": "0.0.1-alpha.632.0",
-            "@ew-did-registry/proxyidentity": "0.0.1-alpha.757.0",
-            "@walletconnect/client": "^1.3.1"
+            "@ew-did-registry/did": "0.1.0-alpha.0",
+            "@ew-did-registry/did-resolver-interface": "0.1.0-alpha.0",
+            "@ew-did-registry/keys": "0.1.0-alpha.0",
+            "@ew-did-registry/proxyidentity": "0.1.0-alpha.0"
           }
         },
         "@ew-did-registry/did-resolver-interface": {
-          "version": "0.0.1-alpha.827.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.0.1-alpha.827.0.tgz",
-          "integrity": "sha512-szxSdMie6os4LI3NwIej6BGnKeo1h2RN6D/Wz2UVx8Da6180+zKsrHjOyIw4IYRrSlcfaxBXMLsLgIWIhWuqHQ==",
+          "version": "0.1.0-alpha.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.1.0-alpha.0.tgz",
+          "integrity": "sha512-eOh5MpZxY6xuCp/XqJ9kUlg7+45H4RBjSxQpTIAKZx8P4Wm9lLlTLkJtb5XfZO6zIptBWvfWxpZX+rDMg/is5g==",
           "requires": {
-            "@ew-did-registry/did": "0.0.1-alpha.632.0"
+            "@ew-did-registry/did": "0.1.0-alpha.0"
           }
         },
         "@ew-did-registry/keys": {
-          "version": "0.0.1-alpha.632.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.0.1-alpha.632.0.tgz",
-          "integrity": "sha512-Xp6IjomDnNNF3Ud/BsuFULz0mULK8XQkhUPcsAG5dXfRr/FfKqSPikd/tQN5IIoKUKej3TOtJ9gri6aGrZ04TA==",
+          "version": "0.1.0-alpha.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.1.0-alpha.0.tgz",
+          "integrity": "sha512-I0RA+cjgXYxEi2YDcx00/n2ytx9R8CcDUHz1FICp1FkyyV4mBePj8NmzaTzM5juHK8if98+VkVUfwYlp1H9sjw==",
           "requires": {
             "eciesjs": "^0.3.4",
             "elliptic": "^6.5.2"
           }
         },
         "@ew-did-registry/proxyidentity": {
-          "version": "0.0.1-alpha.757.0",
-          "resolved": "https://registry.npmjs.org/@ew-did-registry/proxyidentity/-/proxyidentity-0.0.1-alpha.757.0.tgz",
-          "integrity": "sha512-gCLt0tvEdF7Pat7mGZySVBPXnGDt0/FJcXpBdtVoIcAXpyJP4T12EBS3Mv64V8PtyHmXup0oya3Gc2bHj6wlmQ==",
+          "version": "0.1.0-alpha.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/proxyidentity/-/proxyidentity-0.1.0-alpha.0.tgz",
+          "integrity": "sha512-Je7LPXV/4TfgFgpqTNnp3y9ua9BVL/IWEmZqC22qbDJW/E/7aq2NEe6T38ql81T0cOe8YV5bcf32jeSQwyDYWQ==",
           "requires": {
-            "ethers": "4.0.45",
-            "web3": "1.2.6"
+            "ethers": "4.0.45"
           }
         },
         "ethers": {
@@ -3833,9 +4465,12 @@
           "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
         },
         "qs": {
-          "version": "6.9.6",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
-          "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
+          "version": "6.10.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.0.tgz",
+          "integrity": "sha512-yjACOWijC6L/kmPZZAsVBNY2zfHSIbpdpL977quseu56/8BZ2LoF5axK2bGhbzhVKt7V9xgWTtpyLbxwIoER0Q==",
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
         },
         "scrypt-js": {
           "version": "2.0.4",
@@ -4147,6 +4782,11 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
+    "is-bigint": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
+      "integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg=="
+    },
     "is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -4154,6 +4794,14 @@
       "dev": true,
       "requires": {
         "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-boolean-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
+      "integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+      "requires": {
+        "call-bind": "^1.0.0"
       }
     },
     "is-callable": {
@@ -4205,6 +4853,11 @@
       "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
       "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
     },
+    "is-generator-function": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.8.tgz",
+      "integrity": "sha512-2Omr/twNtufVZFr1GhxjOMFPAj2sjc/dKaIqBhvo4qciXfJmITGH6ZGd8eZYNHza8t1y0e01AuqRhJwfWp26WQ=="
+    },
     "is-glob": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
@@ -4247,6 +4900,11 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
+    },
+    "is-number-object": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
+      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw=="
     },
     "is-object": {
       "version": "1.0.1",
@@ -4292,6 +4950,18 @@
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
       "requires": {
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "is-typed-array": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.5.tgz",
+      "integrity": "sha512-S+GRDgJlR3PyEbsX/Fobd9cqpZBuvUS+8asRqYDMLCb2qMzt1oz5m5oxQCxOgUDxiWsOVNi4yaF+/uvdlHlYug==",
+      "requires": {
+        "available-typed-arrays": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "es-abstract": "^1.18.0-next.2",
+        "foreach": "^2.0.5",
         "has-symbols": "^1.0.1"
       }
     },
@@ -4511,8 +5181,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.14.0",
@@ -4537,18 +5206,33 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+    },
     "json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
       "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
     },
     "json-rpc-engine": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-5.4.0.tgz",
-      "integrity": "sha512-rAffKbPoNDjuRnXkecTjnsE3xLLrb00rEkdgalINhaYVYIxDwWtvYBr9UFbhTvPB1B2qUOLoFd/cV6f4Q7mh7g==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-6.1.0.tgz",
+      "integrity": "sha512-NEdLrtrq1jUZyfjkr9OCz9EzCNhnRyWtt1PAnvnhwy6e8XETS0Dtc+ZNCO2gvuAoKsIn2+vCSowXTYE4CkgnAQ==",
       "requires": {
-        "eth-rpc-errors": "^3.0.0",
-        "safe-event-emitter": "^1.0.1"
+        "@metamask/safe-event-emitter": "^2.0.0",
+        "eth-rpc-errors": "^4.0.2"
+      },
+      "dependencies": {
+        "eth-rpc-errors": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/eth-rpc-errors/-/eth-rpc-errors-4.0.3.tgz",
+          "integrity": "sha512-Z3ymjopaoft7JDoxZcEb3pwdGh7yiYMhOwm2doUt6ASXlMavpNlK6Cre0+IMl2VSGyEU9rkiperQhp5iRxn5Pg==",
+          "requires": {
+            "fast-safe-stringify": "^2.0.6"
+          }
+        }
       }
     },
     "json-rpc-random-id": {
@@ -4868,24 +5552,24 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
     },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+    },
     "lodash.difference": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
       "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
-    },
-    "lodash.flatmap": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatmap/-/lodash.flatmap-4.5.0.tgz",
-      "integrity": "sha1-74y/QI9uSCaGYzRTBcaswLd4cC4="
     },
     "lodash.includes": {
       "version": "4.3.0",
@@ -4935,6 +5619,21 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "requires": {
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
     },
     "ltgt": {
       "version": "2.2.1",
@@ -5589,6 +6288,11 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
       "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
+    },
+    "node-releases": {
+      "version": "1.1.71",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
+      "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg=="
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -6537,6 +7241,16 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
+    },
     "signed-varint": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/signed-varint/-/signed-varint-2.0.1.tgz",
@@ -6821,20 +7535,20 @@
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
-      "integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
       "requires": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
-      "integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
       "requires": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
       }
     },
@@ -7271,6 +7985,17 @@
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
       "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
     },
+    "unbox-primitive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.0.tgz",
+      "integrity": "sha512-P/51NX+JXyxK/aigg1/ZgyccdAxm5K1+n8+tvqSntjOivPt19gvm1VC49RWYetsiub8WViUchdxl/KWHHB0kzA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.0",
+        "has-symbols": "^1.0.0",
+        "which-boxed-primitive": "^1.0.1"
+      }
+    },
     "unbzip2-stream": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
@@ -7321,10 +8046,31 @@
       "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
       "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
     },
+    "utf-8-validate": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.4.tgz",
+      "integrity": "sha512-MEF05cPSq3AwJ2C7B7sHAA6i53vONoZbMGX8My5auEVm6W+dJ2Jd/TZPyGJ5CH42V2XtbI5FD28HeHeqlPzZ3Q==",
+      "requires": {
+        "node-gyp-build": "^4.2.0"
+      }
+    },
     "utf8": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
       "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+    },
+    "util": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.3.tgz",
+      "integrity": "sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "safe-buffer": "^5.1.2",
+        "which-typed-array": "^1.1.2"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -8201,6 +8947,19 @@
         }
       }
     },
+    "websocket": {
+      "version": "1.0.33",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.33.tgz",
+      "integrity": "sha512-XwNqM2rN5eh3G2CUQE3OHZj+0xfdH42+OFK6LdC2yqiC0YU8e5UK0nYre220T0IyyN031V/XOvtHvXozvJYFWA==",
+      "requires": {
+        "bufferutil": "^4.0.1",
+        "debug": "^2.2.0",
+        "es5-ext": "^0.10.50",
+        "typedarray-to-buffer": "^3.1.5",
+        "utf-8-validate": "^5.0.2",
+        "yaeti": "^0.0.6"
+      }
+    },
     "whatwg-fetch": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
@@ -8215,10 +8974,36 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "requires": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      }
+    },
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
+    "which-typed-array": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.4.tgz",
+      "integrity": "sha512-49E0SpUe90cjpoc7BOJwyPHRqSAd12c10Qm2amdEZrJPCY2NDxaW01zHITrem+rnETY3dwrbH3UUrUwagfCYDA==",
+      "requires": {
+        "available-typed-arrays": "^1.0.2",
+        "call-bind": "^1.0.0",
+        "es-abstract": "^1.18.0-next.1",
+        "foreach": "^2.0.5",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.1",
+        "is-typed-array": "^1.1.3"
+      }
     },
     "wide-align": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@energyweb/ocn-bridge": "git+https://github.com/energywebfoundation/ocn-bridge.git#v2-update-package-name",
     "better-sqlite3": "^5.4.3",
     "ethers": "^4.0.48",
-    "iam-client-lib": "2.0.0-alpha.3",
+    "iam-client-lib": "2.0.0",
     "nats": "^1.4.12",
     "random-js": "^2.1.0",
     "tslib": "^2.0.3",

--- a/src/ev-registry/factories/iam-client-lib-factory.ts
+++ b/src/ev-registry/factories/iam-client-lib-factory.ts
@@ -1,4 +1,4 @@
-import { CacheServerClient, IAM } from "iam-client-lib"
+import { IAM, setCacheClientOptions } from "iam-client-lib"
 import { config } from "../../config/config"
 
 export class IamClientLibFactory {
@@ -9,16 +9,14 @@ export class IamClientLibFactory {
      * @param isForUserClaims 
      */
     public static async create({ privateKey, cacheServerUrl }: IamClientParams) {
-        const cacheClient = new CacheServerClient({
-            url: cacheServerUrl 
+        setCacheClientOptions(config.prequalification.chainId, {
+            url: cacheServerUrl
         })
 
         // Because iam-client-lib is running on the server, the private key is passed in directly
         const iamClient = new IAM({
             privateKey,
-            rpcUrl: config.prequalification.provider,
-            chainId: config.prequalification.chainId,
-            cacheClient
+            rpcUrl: config.prequalification.provider
         })
 
         // TODO: document why initialization is necessary.


### PR DESCRIPTION
upgrading `iam-client-lib` to 2.0.0. This is needed as we will soon need to update to 2.1.0 due to breaking changes in iam-cache-server