### PR TITLE
feat: add get-private-key command

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -77,7 +77,7 @@ export class Database implements IDIDCache {
     }
 
     public getAssetIdentity(id: string): IAssetIdentity | undefined {
-        const asset = this.db.prepare("SELECT * FROM dids WHERE uid = ?").get(id)
+        const asset = this.db.prepare("SELECT * FROM dids WHERE uid = ?").get(id.toString())
         if (!asset) {
             return
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,32 @@ const createAssetDIDs = async (operatorType: "msp" | "cpo", db: IDIDCache) => {
 }
 
 yargs
+    // tslint:disable-next-line: no-empty
+    .command("get-private-key", "query private key of a DID", () => {}, async (args) => {
+        if (!args.cpo && !args.msp) {
+            console.log("Need one of options \"cpo\", \"msp\"")
+            process.exit(1)
+        }
+        if (!args.did) {
+            console.log("Need device DID")
+            process.exit(1)
+        }
+        let database: Database
+        if (args.cpo) {
+            database = new Database("cpo.db")
+        } else if (args.msp) {
+            database = new Database("msp.db")
+        } else {
+            console.log("Unable to create database at cpo vs msp not known")
+            process.exit(1)
+        }
+        const assetID = database.getAssetIdentityByDID(args.did as string)
+        if (!assetID?.privateKey) {
+            console.log("unable to retrieve private key")
+            process.exit(1)
+        }
+        console.log(assetID.privateKey)
+    })
     .command("mock", "Start a mock OCPI party server", (context) => {
         context
             .option("cpo", {

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,26 +82,33 @@ const createAssetDIDs = async (operatorType: "msp" | "cpo", db: IDIDCache) => {
 
 yargs
     // tslint:disable-next-line: no-empty
-    .command("get-private-key", "query private key of a DID", () => {}, async (args) => {
+    .command("get-private-key", "query private key of a uid", () => { }, async (args) => {
         if (!args.cpo && !args.msp) {
             console.log("Need one of options \"cpo\", \"msp\"")
             process.exit(1)
         }
-        if (!args.did) {
-            console.log("Need device DID")
+        if (!args.uid) {
+            console.log("Need device UID")
             process.exit(1)
         }
         let database: Database
         if (args.cpo) {
+            console.log("Using cpo db")
             database = new Database("cpo.db")
         } else if (args.msp) {
+            console.log("Using msp db")
             database = new Database("msp.db")
         } else {
             console.log("Unable to create database at cpo vs msp not known")
             process.exit(1)
         }
-        const assetID = database.getAssetIdentityByDID(args.did as string)
-        if (!assetID?.privateKey) {
+        console.log(`rerieving privateKey for "${args.uid}"`)
+        const assetID = database.getAssetIdentity(args.uid as string)
+        if (!assetID) {
+            console.log("unable to retrieve assetID")
+            process.exit(1)
+        }
+        if (!assetID.privateKey) {
             console.log("unable to retrieve private key")
             process.exit(1)
         }


### PR DESCRIPTION
Hi Adam. I'm working on adding the data url claims to the `elia-poc` assets. At first I tried integrating the `ev-dashboard-client` classes directly, but I was running into some issues (an `execution reverted from an exception` error) and I think that it is more realistic to use the `ev-dashboard-client` components separately from `ocn-tools` if possible.

Where I'm at so far is that I will:
- Add a new command which outputs the private-key for a given DID. It can be used like this: `docker exec msp-simulation node dist/index.js get-private-key --msp --uid <some-device-uid>` -> **This PR**
- Allow `add-claim` command of `ev-dashboard-client` cli to accept a private key
- Run a separate script as a part of `elia-poc` that calls `get-private-key` followed by `add-claim`. The script can be hardcoded with the uids of `ocn-tools` for now.

Though, I think the best case scenario would be that we dockerize the `asset-operator-server`, then we can pull out all of the DID creation and prequalification out of `ocn-tools` and run it as a part of `elia-poc`... So I guess I should do that instead 🤔 

